### PR TITLE
NIC validation

### DIFF
--- a/pkg/webhook/admission/utils.go
+++ b/pkg/webhook/admission/utils.go
@@ -1,0 +1,11 @@
+package admission
+
+// GetMapKeys gets all keys from a map as a slice
+func GetMapKeys(theMap map[string]string) []string {
+	keys := make([]string, 0, len(theMap))
+
+	for k := range theMap {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/webhook/admission/validator.go
+++ b/pkg/webhook/admission/validator.go
@@ -55,7 +55,7 @@ func validateNic(nic *ovirtsdk.Nic) []ValidationFailure {
 
 	//TODO: Networking rule #1
 
-	if failure, valid := isValidatNicInterfaceModel(nic, nicID); !valid {
+	if failure, valid := isValidNicInterfaceModel(nic, nicID); !valid {
 		results = append(results, failure)
 	}
 	if failure, valid := isValidNicOnBoot(nic, nicID); !valid {
@@ -69,7 +69,7 @@ func validateNic(nic *ovirtsdk.Nic) []ValidationFailure {
 		if failure, valid := isValidVnicPortMirroring(vNicProfile, nicID); !valid {
 			results = append(results, failure)
 		}
-		if failure, valid := isValidVnicProfileMigratable(vNicProfile, nicID); !valid {
+		if failure, valid := isValidVnicProfilePassThrough(vNicProfile, nicID); !valid {
 			results = append(results, failure)
 		}
 		if failure, valid := isValidVnicProfileCustomProperties(vNicProfile, nicID); !valid {
@@ -86,12 +86,12 @@ func validateNic(nic *ovirtsdk.Nic) []ValidationFailure {
 	return results
 }
 
-func isValidatNicInterfaceModel(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool) {
+func isValidNicInterfaceModel(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool) {
 	iFace, ok := nic.Interface()
 	if _, found := validInterfaceDeviceModels[string(iFace)]; !ok || !found {
 		return ValidationFailure{
 			ID:      NicInterfaceCheckID,
-			Message: fmt.Sprintf("interface %v uses model %s that is not supported.", nicID, iFace),
+			Message: fmt.Sprintf("interface %s uses model %s that is not supported.", nicID, iFace),
 		}, false
 	}
 	return ValidationFailure{}, true
@@ -101,7 +101,7 @@ func isValidNicOnBoot(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool)
 	if onBoot, _ := nic.OnBoot(); !onBoot {
 		return ValidationFailure{
 			ID:      NicOnBootID,
-			Message: fmt.Sprintf("interface %v is not enabled on boot.", nicID),
+			Message: fmt.Sprintf("interface %s is not enabled on boot.", nicID),
 		}, false
 	}
 
@@ -112,7 +112,7 @@ func isValidNicPlugged(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool
 	if plugged, _ := nic.Plugged(); !plugged {
 		return ValidationFailure{
 			ID:      NicPluggedID,
-			Message: fmt.Sprintf("interface %v is unplugged.", nicID),
+			Message: fmt.Sprintf("interface %s is unplugged.", nicID),
 		}, false
 	}
 	return ValidationFailure{}, true
@@ -122,18 +122,18 @@ func isValidVnicPortMirroring(vNicProfile *ovirtsdk.VnicProfile, nicID string) (
 	if pm, ok := vNicProfile.PortMirroring(); ok && pm {
 		return ValidationFailure{
 			ID:      NicVNicPortMirroringID,
-			Message: fmt.Sprintf("interface %v uses profile with port mirroring.", nicID),
+			Message: fmt.Sprintf("interface %s uses profile with port mirroring.", nicID),
 		}, false
 	}
 	return ValidationFailure{}, true
 }
 
-func isValidVnicProfileMigratable(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
+func isValidVnicProfilePassThrough(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
 	if pt, ok := vNicProfile.PassThrough(); ok {
 		if ptm, ok := pt.Mode(); ok && string(ptm) == "enabled" {
 			return ValidationFailure{
 				ID:      NicVNicPassThroughID,
-				Message: fmt.Sprintf("interface %v uses profile pass-through enabled.", nicID),
+				Message: fmt.Sprintf("interface %s uses profile pass-through enabled.", nicID),
 			}, false
 		}
 	}
@@ -144,7 +144,7 @@ func isValidVnicProfileCustomProperties(vNicProfile *ovirtsdk.VnicProfile, nicID
 	if cp, ok := vNicProfile.CustomProperties(); ok && len(cp.Slice()) > 0 {
 		return ValidationFailure{
 			ID:      NicVNicCustomPropertiesID,
-			Message: fmt.Sprintf("interface %v uses profile with custom properties: %v.", nicID, cp),
+			Message: fmt.Sprintf("interface %s uses profile with custom properties: %v.", nicID, cp),
 		}, false
 	}
 	return ValidationFailure{}, true
@@ -153,7 +153,7 @@ func isValidVnicProfileNetworFilter(vNicProfile *ovirtsdk.VnicProfile, nicID str
 	if nf, ok := vNicProfile.NetworkFilter(); ok {
 		return ValidationFailure{
 			ID:      NicVNicNetworkFilterID,
-			Message: fmt.Sprintf("interface %v uses profile with a network filter: %v.", nicID, nf),
+			Message: fmt.Sprintf("interface %s uses profile with a network filter: %v.", nicID, nf),
 		}, false
 	}
 	return ValidationFailure{}, true
@@ -162,7 +162,7 @@ func isValidVnicProfileQos(vNicProfile *ovirtsdk.VnicProfile, nicID string) (Val
 	if qos, ok := vNicProfile.Qos(); ok {
 		return ValidationFailure{
 			ID:      NicVNicQosID,
-			Message: fmt.Sprintf("interface %v uses profile with QOS: %v.", nicID, qos),
+			Message: fmt.Sprintf("interface %s uses profile with QOS: %v.", nicID, qos),
 		}, false
 	}
 	return ValidationFailure{}, true

--- a/pkg/webhook/admission/validator.go
+++ b/pkg/webhook/admission/validator.go
@@ -25,7 +25,9 @@ const (
 	NicVNicQosID = CheckID("nic.vnic_profile.qos")
 )
 
-var validInterfaceDeviceModels = map[string]*struct{}{"e1000": nil, "rtl8139": nil, "virtio": nil}
+// TODO: move to shared package with mapping definitions
+// InterfaceModelMapping defines mapping of NIC device models between oVirt and kubevirt domains
+var InterfaceModelMapping = map[string]string{"e1000": "e1000", "rtl8139": "rtl8139", "virtio": "virtio"}
 
 // CheckID identifies validation check for Virtual Machine Import
 type CheckID string
@@ -88,10 +90,10 @@ func validateNic(nic *ovirtsdk.Nic) []ValidationFailure {
 
 func isValidNicInterfaceModel(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool) {
 	iFace, ok := nic.Interface()
-	if _, found := validInterfaceDeviceModels[string(iFace)]; !ok || !found {
+	if _, found := InterfaceModelMapping[string(iFace)]; !ok || !found {
 		return ValidationFailure{
 			ID:      NicInterfaceCheckID,
-			Message: fmt.Sprintf("interface %s uses model %s that is not supported.", nicID, iFace),
+			Message: fmt.Sprintf("interface %s uses model %s that is not supported. Supported models: %v", nicID, iFace, GetMapKeys(InterfaceModelMapping)),
 		}, false
 	}
 	return ValidationFailure{}, true
@@ -149,6 +151,7 @@ func isValidVnicProfileCustomProperties(vNicProfile *ovirtsdk.VnicProfile, nicID
 	}
 	return ValidationFailure{}, true
 }
+
 func isValidVnicProfileNetworFilter(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
 	if nf, ok := vNicProfile.NetworkFilter(); ok {
 		return ValidationFailure{
@@ -158,6 +161,7 @@ func isValidVnicProfileNetworFilter(vNicProfile *ovirtsdk.VnicProfile, nicID str
 	}
 	return ValidationFailure{}, true
 }
+
 func isValidVnicProfileQos(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
 	if qos, ok := vNicProfile.Qos(); ok {
 		return ValidationFailure{

--- a/pkg/webhook/admission/validator.go
+++ b/pkg/webhook/admission/validator.go
@@ -1,0 +1,169 @@
+package admission
+
+import (
+	"fmt"
+
+	ovirtsdk "github.com/ovirt/go-ovirt"
+)
+
+const (
+	// NicInterfaceCheckID defines an ID of a NIC interface model check
+	NicInterfaceCheckID = CheckID("nic.interface")
+	// NicOnBootID defines an ID of a NIC on_boot == fales check
+	NicOnBootID = CheckID("nic.on_boot")
+	// NicPluggedID defines an ID of a NIC plugged == false check
+	NicPluggedID = CheckID("nic.plugged")
+	// NicVNicPortMirroringID defines an ID of a vnic_profile.port_mirroring == true check
+	NicVNicPortMirroringID = CheckID("nic.vnic_profile.port_mirroring")
+	// NicVNicPassThroughID defines an ID of a vnic_profile.pass_through == 'enabled' check
+	NicVNicPassThroughID = CheckID("nic.vnic_profile.pass_through")
+	// NicVNicCustomPropertiesID defines an ID of a vnic_profile.custom_properties presence check
+	NicVNicCustomPropertiesID = CheckID("nic.vnic_profile.custom_properties")
+	// NicVNicNetworkFilterID defines an ID of a vnic_profile.networ_filter presence check
+	NicVNicNetworkFilterID = CheckID("nic.vnic_profile.network_filter")
+	// NicVNicQosID defines an ID of a vnic_profile.qos presence check
+	NicVNicQosID = CheckID("nic.vnic_profile.qos")
+)
+
+var validInterfaceDeviceModels = map[string]*struct{}{"e1000": nil, "rtl8139": nil, "virtio": nil}
+
+// CheckID identifies validation check for Virtual Machine Import
+type CheckID string
+
+// ValidationFailure describes Virtual Machine Import validation failure
+type ValidationFailure struct {
+	// Check ID
+	ID CheckID
+	// Verbose explanation of the failure
+	Message string
+}
+
+func validateNics(nics []*ovirtsdk.Nic) []ValidationFailure {
+	var failures []ValidationFailure
+	for _, nic := range nics {
+		failures = append(failures, validateNic(nic)...)
+	}
+	return failures
+}
+
+func validateNic(nic *ovirtsdk.Nic) []ValidationFailure {
+	var results []ValidationFailure
+	var nicID = ""
+	if id, ok := nic.Id(); ok {
+		nicID = id
+	}
+
+	//TODO: Networking rule #1
+
+	if failure, valid := isValidatNicInterfaceModel(nic, nicID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidNicOnBoot(nic, nicID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidNicPlugged(nic, nicID); !valid {
+		results = append(results, failure)
+	}
+
+	if vNicProfile, ok := nic.VnicProfile(); ok {
+		if failure, valid := isValidVnicPortMirroring(vNicProfile, nicID); !valid {
+			results = append(results, failure)
+		}
+		if failure, valid := isValidVnicProfileMigratable(vNicProfile, nicID); !valid {
+			results = append(results, failure)
+		}
+		if failure, valid := isValidVnicProfileCustomProperties(vNicProfile, nicID); !valid {
+			results = append(results, failure)
+		}
+		if failure, valid := isValidVnicProfileNetworFilter(vNicProfile, nicID); !valid {
+			results = append(results, failure)
+		}
+		if failure, valid := isValidVnicProfileQos(vNicProfile, nicID); !valid {
+			results = append(results, failure)
+		}
+	}
+
+	return results
+}
+
+func isValidatNicInterfaceModel(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool) {
+	iFace, ok := nic.Interface()
+	if _, found := validInterfaceDeviceModels[string(iFace)]; !ok || !found {
+		return ValidationFailure{
+			ID:      NicInterfaceCheckID,
+			Message: fmt.Sprintf("interface %v uses model %s that is not supported.", nicID, iFace),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidNicOnBoot(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool) {
+	if onBoot, _ := nic.OnBoot(); !onBoot {
+		return ValidationFailure{
+			ID:      NicOnBootID,
+			Message: fmt.Sprintf("interface %v is not enabled on boot.", nicID),
+		}, false
+	}
+
+	return ValidationFailure{}, true
+}
+
+func isValidNicPlugged(nic *ovirtsdk.Nic, nicID string) (ValidationFailure, bool) {
+	if plugged, _ := nic.Plugged(); !plugged {
+		return ValidationFailure{
+			ID:      NicPluggedID,
+			Message: fmt.Sprintf("interface %v is unplugged.", nicID),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidVnicPortMirroring(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
+	if pm, ok := vNicProfile.PortMirroring(); ok && pm {
+		return ValidationFailure{
+			ID:      NicVNicPortMirroringID,
+			Message: fmt.Sprintf("interface %v uses profile with port mirroring.", nicID),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidVnicProfileMigratable(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
+	if pt, ok := vNicProfile.PassThrough(); ok {
+		if ptm, ok := pt.Mode(); ok && string(ptm) == "enabled" {
+			return ValidationFailure{
+				ID:      NicVNicPassThroughID,
+				Message: fmt.Sprintf("interface %v uses profile pass-through enabled.", nicID),
+			}, false
+		}
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidVnicProfileCustomProperties(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
+	if cp, ok := vNicProfile.CustomProperties(); ok && len(cp.Slice()) > 0 {
+		return ValidationFailure{
+			ID:      NicVNicCustomPropertiesID,
+			Message: fmt.Sprintf("interface %v uses profile with custom properties: %v.", nicID, cp),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+func isValidVnicProfileNetworFilter(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
+	if nf, ok := vNicProfile.NetworkFilter(); ok {
+		return ValidationFailure{
+			ID:      NicVNicNetworkFilterID,
+			Message: fmt.Sprintf("interface %v uses profile with a network filter: %v.", nicID, nf),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+func isValidVnicProfileQos(vNicProfile *ovirtsdk.VnicProfile, nicID string) (ValidationFailure, bool) {
+	if qos, ok := vNicProfile.Qos(); ok {
+		return ValidationFailure{
+			ID:      NicVNicQosID,
+			Message: fmt.Sprintf("interface %v uses profile with QOS: %v.", nicID, qos),
+		}, false
+	}
+	return ValidationFailure{}, true
+}

--- a/pkg/webhook/admission/validator_test.go
+++ b/pkg/webhook/admission/validator_test.go
@@ -1,0 +1,171 @@
+package admission
+
+import (
+	"fmt"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	ovirtsdk "github.com/ovirt/go-ovirt"
+)
+
+var _ = Describe("Validating NIC", func() {
+	// Private API tests
+	table.DescribeTable("should flag nic with illegal interface model: ", func(iface string) {
+		var nic = newNic()
+		nic.SetInterface(ovirtsdk.NicInterface(iface))
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicInterfaceCheckID))
+	},
+		table.Entry("pci_passthrough", "pci_passthrough"),
+		table.Entry("spapr_vlan", "spapr_vlan"),
+		table.Entry("rtl8139_virtio", "rtl8139_virtio"),
+		table.Entry("garbage", "lkfsldfksld3432432#$#@"),
+		table.Entry("empty string", ""),
+	)
+
+	table.DescribeTable("should accept nic with legal interface model: ", func(iface string) {
+		var nic = newNic()
+		nic.SetInterface(ovirtsdk.NicInterface(iface))
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(0))
+	},
+		table.Entry("virtio", "virtio"),
+		table.Entry("e1000", "e1000"),
+		table.Entry("rtl8139", "rtl8139"),
+	)
+	It("should flag nic without interface: ", func() {
+		nic := ovirtsdk.Nic{}
+		nic.SetId("NIC_id")
+		nic.SetPlugged(true)
+		nic.SetOnBoot(true)
+
+		failures := validateNic(&nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicInterfaceCheckID))
+	})
+	It("should flag nic with on_boot == false: ", func() {
+		var nic = newNic()
+		nic.SetOnBoot(false)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicOnBootID))
+	})
+	It("should flag nic with plugged == false: ", func() {
+		var nic = newNic()
+		nic.SetPlugged(false)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicPluggedID))
+	})
+	It("should flag nic with port mirroring: ", func() {
+		var nic = newNic()
+		nic.MustVnicProfile().SetPortMirroring(true)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicVNicPortMirroringID))
+	})
+	It("should flag nic with pass-through == 'enabled': ", func() {
+		var nic = newNic()
+		passThrough := ovirtsdk.VnicPassThrough{}
+		passThrough.SetMode(ovirtsdk.VnicPassThroughMode("enabled"))
+		profile := nic.MustVnicProfile()
+		profile.SetPassThrough(&passThrough)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicVNicPassThroughID))
+	})
+	It("should flag nic with some custom_properties ", func() {
+		var nic = newNic()
+		nic.MustVnicProfile()
+		profile := nic.MustVnicProfile()
+
+		property := ovirtsdk.CustomProperty{}
+		property.SetName("property name")
+		customPropertySlice := []*ovirtsdk.CustomProperty{&property}
+		properties := ovirtsdk.CustomPropertySlice{}
+		properties.SetSlice(customPropertySlice)
+		profile.SetCustomProperties(&properties)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicVNicCustomPropertiesID))
+	})
+	It("should flag nic with network filter ", func() {
+		var nic = newNic()
+		nic.MustVnicProfile()
+		profile := nic.MustVnicProfile()
+
+		filter := ovirtsdk.NetworkFilter{}
+		profile.SetNetworkFilter(&filter)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicVNicNetworkFilterID))
+	})
+	It("should flag nic with QOS ", func() {
+		var nic = newNic()
+		nic.MustVnicProfile()
+		profile := nic.MustVnicProfile()
+
+		qos := ovirtsdk.Qos{}
+		profile.SetQos(&qos)
+
+		failures := validateNic(nic)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(NicVNicQosID))
+	})
+	It("should not flag two nics ", func() {
+		nic1 := newNic()
+		nic2 := newNic()
+		nics := []*ovirtsdk.Nic{nic1, nic2}
+		failures := validateNics(nics)
+
+		Expect(failures).To(HaveLen(0))
+	})
+	It("should flag two nics ", func() {
+		nic1 := newNic()
+		nic1.SetPlugged(false)
+		nic2 := newNic()
+		nic2.SetOnBoot(false)
+		nics := []*ovirtsdk.Nic{nic1, nic2}
+		failures := validateNics(nics)
+
+		Expect(failures).To(HaveLen(2))
+
+		var checkIDs = [2]CheckID{failures[0].ID, failures[1].ID}
+		Expect(checkIDs).To(ContainElement(NicPluggedID))
+		Expect(checkIDs).To(ContainElement(NicOnBootID))
+	})
+})
+
+func newNic() *ovirtsdk.Nic {
+	vnicProfile := ovirtsdk.VnicProfile{}
+	vnicProfile.SetName("A Vnic Profile")
+
+	nic := ovirtsdk.Nic{}
+	nic.SetId(fmt.Sprintf("ID_%d", rand.Int()))
+	nic.SetPlugged(true)
+	nic.SetOnBoot(true)
+	nic.SetVnicProfile(&vnicProfile)
+	nic.SetInterface(ovirtsdk.NicInterface("virtio"))
+	return &nic
+}


### PR DESCRIPTION
First proper validations - performed against NIC. The result of the validation will be interpreted in the caller and transformed into `k8s.io/apimachinery/pkg/apis/meta/v1.StatusCause` or logged.
This PR shows the general direction of validation implementation.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>