### PR TITLE
Storage rules

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,7 @@ github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413/go.mod h1:BeS3M108VzVl
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64/go.mod h1:RYlF4ghFZPPmk2TC5REt5OFwvfb6lzxFWrTWB+qs28s=
 github.com/helm/helm-2to3 v0.2.0/go.mod h1:jQUVAWB0bM7zNIqKPIfHFzuFSK0kHYovJrjO+hqcvRk=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -552,6 +553,7 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -560,6 +562,7 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.1-0.20190515112211-6a48b4839f85/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -1004,6 +1007,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v1 v1.1.2/go.mod h1:QpYS+a4WhS+DTlyQIi6Ka7MS3SuR9a055rgXNEe6EiA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/pkg/webhook/admission/definitions.go
+++ b/pkg/webhook/admission/definitions.go
@@ -1,0 +1,59 @@
+package admission
+
+const (
+	// NicInterfaceCheckID defines an ID of a NIC interface model check
+	NicInterfaceCheckID = CheckID("nic.interface")
+	// NicOnBootID defines an ID of a NIC on_boot == fales check
+	NicOnBootID = CheckID("nic.on_boot")
+	// NicPluggedID defines an ID of a NIC plugged == false check
+	NicPluggedID = CheckID("nic.plugged")
+	// NicVNicPortMirroringID defines an ID of a vnic_profile.port_mirroring == true check
+	NicVNicPortMirroringID = CheckID("nic.vnic_profile.port_mirroring")
+	// NicVNicPassThroughID defines an ID of a vnic_profile.pass_through == 'enabled' check
+	NicVNicPassThroughID = CheckID("nic.vnic_profile.pass_through")
+	// NicVNicCustomPropertiesID defines an ID of a vnic_profile.custom_properties presence check
+	NicVNicCustomPropertiesID = CheckID("nic.vnic_profile.custom_properties")
+	// NicVNicNetworkFilterID defines an ID of a vnic_profile.networ_filter presence check
+	NicVNicNetworkFilterID = CheckID("nic.vnic_profile.network_filter")
+	// NicVNicQosID defines an ID of a vnic_profile.qos presence check
+	NicVNicQosID = CheckID("nic.vnic_profile.qos")
+	// DiskAttachmentInterfaceID defines an ID of a disk attachment interface check
+	DiskAttachmentInterfaceID = CheckID("disk_attachment.interface")
+	// DiskAttachmentLogicalNameID defines an ID of a disk_attachment.logical_name check
+	DiskAttachmentLogicalNameID = CheckID("disk_attachment.logical_name")
+	// DiskAttachmentPassDiscardID defines an ID of a disk_attachment.pass_discard == true check
+	DiskAttachmentPassDiscardID = CheckID("disk_attachment.pass_discard")
+	// DiskAttachmentUsesScsiReservationID defines and ID of a disk_attachment.uses_scsi_reservation == true check
+	DiskAttachmentUsesScsiReservationID = CheckID("disk_attachment.uses_scsi_reservation")
+	// DiskInterfaceID defines an ID of a disk interface check
+	DiskInterfaceID = CheckID("disk_attachment.disk.interface")
+	// DiskLogicalNameID defines an ID of a disk.logical_name check
+	DiskLogicalNameID = CheckID("disk_attachment.disk.logical_name")
+	// DiskUsesScsiReservationID defines an ID of a disk.uses_scsi_reservation == true check
+	DiskUsesScsiReservationID = CheckID("disk_attachment.disk.uses_scsi_reservation")
+	// DiskBackupID defines an ID of a disk.backup == 'incremental' check
+	DiskBackupID = CheckID("disk_attachment.disk.backup")
+	// DiskLunStorageID defines an ID of a disk.lun_storage presence check
+	DiskLunStorageID = CheckID("disk_attachment.disk.lun_storage")
+	// DiskPropagateErrorsID defines an ID of a disk.propagate_errors presence check
+	DiskPropagateErrorsID = CheckID("disk_attachment.disk.propagate_errors")
+	// DiskWipeAfterDeleteID defines an ID of a disk.wipe_after_delete == true check
+	DiskWipeAfterDeleteID = CheckID("disk_attachment.disk.wipe_after_delete")
+	// DiskStatusID defines an ID of a disk.status == 'ok'
+	DiskStatusID = CheckID("disk_attachment.disk.status")
+	// DiskStoragaTypeID defines an ID of a disk.storage_type != image check
+	DiskStoragaTypeID = CheckID("disk_attachment.disk.storage_type")
+	// DiskSgioID defines and ID of a disk.sgio == true check
+	DiskSgioID = CheckID("disk_attachment.disk.sgio")
+)
+
+// CheckID identifies validation check for Virtual Machine Import
+type CheckID string
+
+// ValidationFailure describes Virtual Machine Import validation failure
+type ValidationFailure struct {
+	// Check ID
+	ID CheckID
+	// Verbose explanation of the failure
+	Message string
+}

--- a/pkg/webhook/admission/nic-validator.go
+++ b/pkg/webhook/admission/nic-validator.go
@@ -6,39 +6,10 @@ import (
 	ovirtsdk "github.com/ovirt/go-ovirt"
 )
 
-const (
-	// NicInterfaceCheckID defines an ID of a NIC interface model check
-	NicInterfaceCheckID = CheckID("nic.interface")
-	// NicOnBootID defines an ID of a NIC on_boot == fales check
-	NicOnBootID = CheckID("nic.on_boot")
-	// NicPluggedID defines an ID of a NIC plugged == false check
-	NicPluggedID = CheckID("nic.plugged")
-	// NicVNicPortMirroringID defines an ID of a vnic_profile.port_mirroring == true check
-	NicVNicPortMirroringID = CheckID("nic.vnic_profile.port_mirroring")
-	// NicVNicPassThroughID defines an ID of a vnic_profile.pass_through == 'enabled' check
-	NicVNicPassThroughID = CheckID("nic.vnic_profile.pass_through")
-	// NicVNicCustomPropertiesID defines an ID of a vnic_profile.custom_properties presence check
-	NicVNicCustomPropertiesID = CheckID("nic.vnic_profile.custom_properties")
-	// NicVNicNetworkFilterID defines an ID of a vnic_profile.networ_filter presence check
-	NicVNicNetworkFilterID = CheckID("nic.vnic_profile.network_filter")
-	// NicVNicQosID defines an ID of a vnic_profile.qos presence check
-	NicVNicQosID = CheckID("nic.vnic_profile.qos")
-)
-
 // TODO: move to shared package with mapping definitions
+
 // InterfaceModelMapping defines mapping of NIC device models between oVirt and kubevirt domains
 var InterfaceModelMapping = map[string]string{"e1000": "e1000", "rtl8139": "rtl8139", "virtio": "virtio"}
-
-// CheckID identifies validation check for Virtual Machine Import
-type CheckID string
-
-// ValidationFailure describes Virtual Machine Import validation failure
-type ValidationFailure struct {
-	// Check ID
-	ID CheckID
-	// Verbose explanation of the failure
-	Message string
-}
 
 func validateNics(nics []*ovirtsdk.Nic) []ValidationFailure {
 	var failures []ValidationFailure

--- a/pkg/webhook/admission/nic-validator_test.go
+++ b/pkg/webhook/admission/nic-validator_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 var _ = Describe("Validating NIC", func() {
-	// Private API tests
 	table.DescribeTable("should flag nic with illegal interface model: ", func(iface string) {
 		var nic = newNic()
 		nic.SetInterface(ovirtsdk.NicInterface(iface))
@@ -27,14 +26,13 @@ var _ = Describe("Validating NIC", func() {
 		table.Entry("garbage", "lkfsldfksld3432432#$#@"),
 		table.Entry("empty string", ""),
 	)
-
 	table.DescribeTable("should accept nic with legal interface model: ", func(iface string) {
 		var nic = newNic()
 		nic.SetInterface(ovirtsdk.NicInterface(iface))
 
 		failures := validateNic(nic)
 
-		Expect(failures).To(HaveLen(0))
+		Expect(failures).To(BeEmpty())
 	},
 		table.Entry("virtio", "virtio"),
 		table.Entry("e1000", "e1000"),
@@ -139,7 +137,7 @@ var _ = Describe("Validating NIC", func() {
 		nics := []*ovirtsdk.Nic{nic1, nic2}
 		failures := validateNics(nics)
 
-		Expect(failures).To(HaveLen(0))
+		Expect(failures).To(BeEmpty())
 	})
 	It("should flag two nics ", func() {
 		nic1 := newNic()

--- a/pkg/webhook/admission/storage-validator.go
+++ b/pkg/webhook/admission/storage-validator.go
@@ -1,0 +1,226 @@
+package admission
+
+import (
+	"fmt"
+
+	ovirtsdk "github.com/ovirt/go-ovirt"
+)
+
+// DiskInterfaceModelMapping defines mapping of disk interface models between oVirt and kubevirt domains
+var DiskInterfaceModelMapping = map[string]string{"sata": "sata", "virtio_scsi": "virtio", "virtio": "virtio"}
+
+//DiskInterfaceOwner defines means of getting interface of a storage entity
+type DiskInterfaceOwner interface {
+	Interface() (ovirtsdk.DiskInterface, bool)
+}
+
+//DiskLogicalNameOwner defines means of getting logical name of a storage entity
+type DiskLogicalNameOwner interface {
+	LogicalName() (string, bool)
+}
+
+//UsesScsiReservationOwner defines means of getting uses scsi reservation flag value of a storage entity
+type UsesScsiReservationOwner interface {
+	UsesScsiReservation() (bool, bool)
+}
+
+func validateDiskAttachment(diskAttachment *ovirtsdk.DiskAttachment) []ValidationFailure {
+	var results []ValidationFailure
+	var attachmentID = ""
+	if id, ok := diskAttachment.Id(); ok {
+		attachmentID = id
+	}
+
+	if failure, valid := isValidDiskAttachmentInterface(diskAttachment, attachmentID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskAttachmentLogicalName(diskAttachment, attachmentID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskAttachmentPassDiscard(diskAttachment, attachmentID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskAttachmentUsesScsiReservation(diskAttachment, attachmentID); !valid {
+		results = append(results, failure)
+	}
+	if disk, ok := diskAttachment.Disk(); ok {
+		results = append(results, validateDisk(disk)...)
+	}
+	return results
+}
+
+func validateDisk(disk *ovirtsdk.Disk) []ValidationFailure {
+	var results []ValidationFailure
+	var diskID = ""
+	if id, ok := disk.Id(); ok {
+		diskID = id
+	}
+	if failure, valid := isValidDiskInterface(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskLogicalName(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskUsesScsiReservation(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskBackup(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskLunStorage(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskPropagateErrors(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskWipeAfterDelete(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskStatus(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskStorageType(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+	if failure, valid := isValidDiskSgio(disk, diskID); !valid {
+		results = append(results, failure)
+	}
+
+	return results
+}
+
+func isValidDiskAttachmentInterface(diskAttachment *ovirtsdk.DiskAttachment, attachmentID string) (ValidationFailure, bool) {
+	return isValidStorageInterface(diskAttachment, attachmentID, DiskAttachmentInterfaceID)
+}
+
+func isValidDiskInterface(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	return isValidStorageInterface(disk, diskID, DiskInterfaceID)
+}
+
+func isValidStorageInterface(diskAttachment DiskInterfaceOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
+	iface, _ := diskAttachment.Interface()
+	if _, found := DiskInterfaceModelMapping[string(iface)]; !found {
+		return ValidationFailure{
+			ID:      checkID,
+			Message: fmt.Sprintf("%s %s uses interface %v. Allowed values: %v", checkID, ownerID, iface, GetMapKeys(DiskInterfaceModelMapping)),
+		}, false
+	}
+
+	return ValidationFailure{}, true
+}
+
+func isValidDiskAttachmentLogicalName(diskAttachment *ovirtsdk.DiskAttachment, attachmentID string) (ValidationFailure, bool) {
+	return isValidStorageLogicalName(diskAttachment, attachmentID, DiskAttachmentLogicalNameID)
+}
+
+func isValidDiskLogicalName(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	return isValidStorageLogicalName(disk, diskID, DiskLogicalNameID)
+}
+
+func isValidStorageLogicalName(logicalNameOwner DiskLogicalNameOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
+	if logicalName, ok := logicalNameOwner.LogicalName(); ok {
+		return ValidationFailure{
+			ID:      checkID,
+			Message: fmt.Sprintf("%s %s has logical name of %s defined", checkID, ownerID, logicalName),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskAttachmentPassDiscard(diskAttachment *ovirtsdk.DiskAttachment, attachmentID string) (ValidationFailure, bool) {
+	if pd, ok := diskAttachment.PassDiscard(); ok && pd {
+		return ValidationFailure{
+			ID:      DiskAttachmentPassDiscardID,
+			Message: fmt.Sprintf("disk attachment %s has pass_discard == true", attachmentID),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskAttachmentUsesScsiReservation(diskAttachment *ovirtsdk.DiskAttachment, attachmentID string) (ValidationFailure, bool) {
+	return isValidStorageUsesScsiReservation(diskAttachment, attachmentID, DiskAttachmentUsesScsiReservationID)
+}
+
+func isValidDiskUsesScsiReservation(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	return isValidStorageUsesScsiReservation(disk, diskID, DiskUsesScsiReservationID)
+}
+
+func isValidStorageUsesScsiReservation(owner UsesScsiReservationOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
+	if sr, ok := owner.UsesScsiReservation(); ok && sr {
+		return ValidationFailure{
+			ID:      checkID,
+			Message: fmt.Sprintf("%s %s has uses_scsi_reservation == true", checkID, ownerID),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskBackup(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if backup, ok := disk.Backup(); ok && backup == "incremental" {
+		return ValidationFailure{
+			ID:      DiskBackupID,
+			Message: fmt.Sprintf("disk %s uses backup == 'incremental'. Allowed value: 'none'.", diskID),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskLunStorage(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if storage, ok := disk.LunStorage(); ok {
+		return ValidationFailure{
+			ID:      DiskLunStorageID,
+			Message: fmt.Sprintf("disk %s uses LUN storage: %v", diskID, storage),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskPropagateErrors(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if propagate, ok := disk.PropagateErrors(); ok {
+		return ValidationFailure{
+			ID:      DiskPropagateErrorsID,
+			Message: fmt.Sprintf("disk %s has propagate_errors configured: %t", diskID, propagate),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskWipeAfterDelete(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if enabled, ok := disk.WipeAfterDelete(); ok && enabled {
+		return ValidationFailure{
+			ID:      DiskWipeAfterDeleteID,
+			Message: fmt.Sprintf("disk %s has wipe_after_delete enabled", diskID),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskStatus(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if status, ok := disk.Status(); ok && status != "ok" {
+		return ValidationFailure{
+			ID:      DiskStatusID,
+			Message: fmt.Sprintf("disk %s has illegal status: '%v'. Allowed value: 'ok'", diskID, status),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskStorageType(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if storageType, ok := disk.StorageType(); !ok || storageType != "image" {
+		return ValidationFailure{
+			ID:      DiskStoragaTypeID,
+			Message: fmt.Sprintf("disk %s has illegal storage type: '%v'. Allowed value: 'image'", diskID, storageType),
+		}, false
+	}
+	return ValidationFailure{}, true
+}
+
+func isValidDiskSgio(disk *ovirtsdk.Disk, diskID string) (ValidationFailure, bool) {
+	if sgio, ok := disk.Sgio(); ok && sgio != "disabled" {
+		return ValidationFailure{
+			ID:      DiskSgioID,
+			Message: fmt.Sprintf("disk %s has illegal sgio setting: '%v'. Allowed value: 'disabled'", diskID, sgio),
+		}, false
+	}
+	return ValidationFailure{}, true
+}

--- a/pkg/webhook/admission/storage-validator_test.go
+++ b/pkg/webhook/admission/storage-validator_test.go
@@ -1,0 +1,261 @@
+package admission
+
+import (
+	"fmt"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	ovirtsdk "github.com/ovirt/go-ovirt"
+)
+
+var _ = Describe("Validating Disk Attachment", func() {
+	table.DescribeTable("should flag disk attachment with illegal interface: ", func(iface string) {
+		var attachment = newDiskAttachment()
+		attachment.SetInterface(ovirtsdk.DiskInterface(iface))
+
+		failures := validateDiskAttachment(attachment)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskAttachmentInterfaceID))
+	},
+		table.Entry("ide", "pci"),
+		table.Entry("spapr_vscsi", "spapr_vscsi"),
+
+		table.Entry("garbage", "123saas-#$#@"),
+		table.Entry("empty string", ""),
+	)
+	table.DescribeTable("should accept disk attachment with legal interface: ", func(iface string) {
+		var attachment = newDiskAttachment()
+		attachment.SetInterface(ovirtsdk.DiskInterface(iface))
+
+		failures := validateDiskAttachment(attachment)
+
+		Expect(failures).To(BeEmpty())
+	},
+		table.Entry("virtio", "virtio"),
+		table.Entry("sata", "sata"),
+		table.Entry("virtio_scsi", "virtio_scsi"),
+	)
+	It("should flag disk attachment without interface: ", func() {
+		attachment := ovirtsdk.DiskAttachment{}
+		attachment.SetId("Attachment_id")
+
+		failures := validateDiskAttachment(&attachment)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskAttachmentInterfaceID))
+	})
+	It("should flag disk attachment with logical name: ", func() {
+		attachment := newDiskAttachment()
+		attachment.SetLogicalName("/dev/sdMy")
+
+		failures := validateDiskAttachment(attachment)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskAttachmentLogicalNameID))
+	})
+	It("should flag disk attachment with pass_discard == true: ", func() {
+		attachment := newDiskAttachment()
+		attachment.SetPassDiscard(true)
+
+		failures := validateDiskAttachment(attachment)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskAttachmentPassDiscardID))
+	})
+	It("should flag disk attachment with uses_scsi_reservation == true: ", func() {
+		attachment := newDiskAttachment()
+		attachment.SetUsesScsiReservation(true)
+
+		failures := validateDiskAttachment(attachment)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskAttachmentUsesScsiReservationID))
+	})
+})
+
+func newDiskAttachment() *ovirtsdk.DiskAttachment {
+	diskAttachment := ovirtsdk.DiskAttachment{}
+	diskAttachment.SetId(fmt.Sprintf("ID_%d", rand.Int()))
+	diskAttachment.SetInterface(ovirtsdk.DiskInterface("virtio"))
+	diskAttachment.SetDisk(newDisk())
+	return &diskAttachment
+}
+
+var _ = Describe("Validating Disk", func() {
+	table.DescribeTable("should flag disk with illegal interface: ", func(iface string) {
+		var disk = newDisk()
+		disk.SetInterface(ovirtsdk.DiskInterface(iface))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskInterfaceID))
+	},
+		table.Entry("ide", "ide"),
+		table.Entry("spapr_vscsi", "spapr_vscsi"),
+
+		table.Entry("garbage", "123saas-#$#@"),
+		table.Entry("empty string", ""),
+	)
+	table.DescribeTable("should accept disk with legal interface: ", func(iface string) {
+		var disk = newDisk()
+		disk.SetInterface(ovirtsdk.DiskInterface(iface))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(BeEmpty())
+	},
+		table.Entry("virtio", "virtio"),
+		table.Entry("sata", "sata"),
+		table.Entry("virtio_scsi", "virtio_scsi"),
+	)
+	It("should flag disk attachment without interface: ", func() {
+		disk := ovirtsdk.Disk{}
+		disk.SetId("Disk_id")
+		disk.SetStorageType("image")
+
+		failures := validateDisk(&disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskInterfaceID))
+	})
+	It("should flag disk with logical name: ", func() {
+		disk := newDisk()
+		disk.SetLogicalName("/dev/sdMy")
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskLogicalNameID))
+	})
+	It("should flag disk with uses_scsi_reservation == true: ", func() {
+		disk := newDisk()
+		disk.SetUsesScsiReservation(true)
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskUsesScsiReservationID))
+	})
+	It("should flag disk with backup == 'incremental': ", func() {
+		disk := newDisk()
+		disk.SetBackup(ovirtsdk.DiskBackup("incremental"))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskBackupID))
+	})
+	It("should flag disk with lun_storage present: ", func() {
+		disk := newDisk()
+		lunStorage := ovirtsdk.HostStorage{}
+		disk.SetLunStorage(&lunStorage)
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskLunStorageID))
+	})
+	It("should flag disk with propagate_errors == true setting present: ", func() {
+		disk := newDisk()
+		disk.SetPropagateErrors(true)
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskPropagateErrorsID))
+	})
+	It("should flag disk with propagate_errors == false setting present: ", func() {
+		disk := newDisk()
+		disk.SetPropagateErrors(false)
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskPropagateErrorsID))
+	})
+	It("should flag disk with wipe_after_delete == true setting present: ", func() {
+		disk := newDisk()
+		disk.SetWipeAfterDelete(true)
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskWipeAfterDeleteID))
+	})
+	table.DescribeTable("should flag disk with illegal status: ", func(status string) {
+		var disk = newDisk()
+		disk.SetStatus(ovirtsdk.DiskStatus(status))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskStatusID))
+	},
+		table.Entry("illegal", "illegal"),
+		table.Entry("locked", "locked"),
+
+		table.Entry("garbage", "123saas-#$#@"),
+		table.Entry("empty string", ""),
+	)
+	table.DescribeTable("should flag disk with illegal storage types: ", func(storageType string) {
+		var disk = newDisk()
+		disk.SetStorageType(ovirtsdk.DiskStorageType(storageType))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskStoragaTypeID))
+	},
+		table.Entry("cinder", "cinder"),
+		table.Entry("lun", "lun"),
+		table.Entry("Managed block storage", "managed_block_storage"),
+
+		table.Entry("garbage", "123saas-#$#@"),
+		table.Entry("empty string", ""),
+	)
+	It("should flag disk without storage type: ", func() {
+		disk := ovirtsdk.Disk{}
+		disk.SetId("Disk_id")
+		disk.SetInterface(ovirtsdk.DiskInterface("virtio"))
+
+		failures := validateDisk(&disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskStoragaTypeID))
+	})
+	It("should allow for disk with disabled sgio: ", func() {
+		disk := newDisk()
+		disk.SetSgio(ovirtsdk.ScsiGenericIO("disabled"))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(BeEmpty())
+	})
+	table.DescribeTable("should flag disk with illegal sgio settings: ", func(sgio string) {
+		var disk = newDisk()
+		disk.SetSgio(ovirtsdk.ScsiGenericIO(sgio))
+
+		failures := validateDisk(disk)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(DiskSgioID))
+	},
+		table.Entry("Filtered", "filtered"),
+		table.Entry("Unfiltered", "unfiltered"),
+	)
+})
+
+func newDisk() *ovirtsdk.Disk {
+	disk := ovirtsdk.Disk{}
+	disk.SetId(fmt.Sprintf("ID_%d", rand.Int()))
+	disk.SetInterface(ovirtsdk.DiskInterface("virtio"))
+	disk.SetStatus("ok")
+	disk.SetWipeAfterDelete(false)
+	disk.SetBackup("none")
+	disk.SetStorageType("image")
+	return &disk
+}

--- a/pkg/webhook/admission/vm-import-validation.go
+++ b/pkg/webhook/admission/vm-import-validation.go
@@ -4,6 +4,41 @@ import (
 	"k8s.io/api/admission/v1beta1"
 )
 
+type action int
+
+const (
+	log   = 0
+	warn  = 1
+	block = 2
+)
+
+var checkToAction = map[CheckID]action{
+	// NIC rules
+	NicInterfaceCheckID:       block,
+	NicOnBootID:               log,
+	NicPluggedID:              warn,
+	NicVNicPassThroughID:      block,
+	NicVNicPortMirroringID:    warn,
+	NicVNicCustomPropertiesID: warn,
+	NicVNicNetworkFilterID:    warn,
+	NicVNicQosID:              log,
+	// Storage rules
+	DiskAttachmentInterfaceID:           block,
+	DiskAttachmentLogicalNameID:         log,
+	DiskAttachmentPassDiscardID:         log,
+	DiskAttachmentUsesScsiReservationID: block,
+	DiskInterfaceID:                     block,
+	DiskLogicalNameID:                   log,
+	DiskUsesScsiReservationID:           block,
+	DiskBackupID:                        warn,
+	DiskLunStorageID:                    block,
+	DiskPropagateErrorsID:               log,
+	DiskWipeAfterDeleteID:               log,
+	DiskStatusID:                        block,
+	DiskStoragaTypeID:                   block,
+	DiskSgioID:                          block,
+}
+
 // VirtualMachineImportAdmitter validates VirtualMachineImport object
 type VirtualMachineImportAdmitter struct {
 }


### PR DESCRIPTION
This PR:
-  defines validation rules for storage;
-  puts different sets of validators in separate files (networking, storage);
-  introduces `CheckID`:`action` map that will be used in the hook to decide what strategy should be executed to deal with specific `ValidationFailure`. Strategies to be implemented in other PR.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>