### PR TITLE
Validation rules fixes

### DIFF
--- a/pkg/providers/ovirt/validation/validators/storage-validator.go
+++ b/pkg/providers/ovirt/validation/validators/storage-validator.go
@@ -105,12 +105,13 @@ func isValidDiskInterface(disk *ovirtsdk.Disk, diskID string) (ValidationFailure
 }
 
 func isValidStorageInterface(diskAttachment DiskInterfaceOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
-	iface, _ := diskAttachment.Interface()
-	if _, found := DiskInterfaceModelMapping[string(iface)]; !found {
-		return ValidationFailure{
-			ID:      checkID,
-			Message: fmt.Sprintf("%s %s uses interface %v. Allowed values: %v", checkID, ownerID, iface, GetMapKeys(DiskInterfaceModelMapping)),
-		}, false
+	if iface, ok := diskAttachment.Interface(); ok {
+		if _, found := DiskInterfaceModelMapping[string(iface)]; !found {
+			return ValidationFailure{
+				ID:      checkID,
+				Message: fmt.Sprintf("%s %s uses interface %v. Allowed values: %v", checkID, ownerID, iface, GetMapKeys(DiskInterfaceModelMapping)),
+			}, false
+		}
 	}
 
 	return ValidationFailure{}, true

--- a/pkg/providers/ovirt/validation/validators/storage-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/storage-validator_test.go
@@ -38,15 +38,6 @@ var _ = Describe("Validating Disk Attachment", func() {
 		table.Entry("sata", "sata"),
 		table.Entry("virtio_scsi", "virtio_scsi"),
 	)
-	It("should flag disk attachment without interface: ", func() {
-		attachment := ovirtsdk.DiskAttachment{}
-		attachment.SetId("Attachment_id")
-
-		failures := validateDiskAttachment(&attachment)
-
-		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(DiskAttachmentInterfaceID))
-	})
 	It("should flag disk attachment with logical name: ", func() {
 		attachment := newDiskAttachment()
 		attachment.SetLogicalName("/dev/sdMy")
@@ -112,16 +103,6 @@ var _ = Describe("Validating Disk", func() {
 		table.Entry("sata", "sata"),
 		table.Entry("virtio_scsi", "virtio_scsi"),
 	)
-	It("should flag disk attachment without interface: ", func() {
-		disk := ovirtsdk.Disk{}
-		disk.SetId("Disk_id")
-		disk.SetStorageType("image")
-
-		failures := validateDisk(&disk)
-
-		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(DiskInterfaceID))
-	})
 	It("should flag disk with logical name: ", func() {
 		disk := newDisk()
 		disk.SetLogicalName("/dev/sdMy")

--- a/pkg/providers/ovirt/validation/validators/vm-validator.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator.go
@@ -375,11 +375,13 @@ func isValidStorageErrorResumeBehaviour(vm *ovirtsdk.Vm) (ValidationFailure, boo
 }
 
 func isValidUsb(vm *ovirtsdk.Vm) (ValidationFailure, bool) {
-	if _, ok := vm.Usb(); ok {
-		return ValidationFailure{
-			ID:      VMUsbID,
-			Message: fmt.Sprintf("VM has USB configured"),
-		}, false
+	if usb, ok := vm.Usb(); ok {
+		if enabled, ok := usb.Enabled(); ok && enabled {
+			return ValidationFailure{
+				ID:      VMUsbID,
+				Message: fmt.Sprintf("VM has USB enabled"),
+			}, false
+		}
 	}
 	return ValidationFailure{}, true
 }

--- a/pkg/providers/ovirt/validation/validators/vm-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator_test.go
@@ -257,9 +257,10 @@ var _ = Describe("Validating VM", func() {
 		Expect(failures).To(HaveLen(1))
 		Expect(failures[0].ID).To(Equal(VMTunnelMigrationID))
 	})
-	It("should flag vm with USB configured", func() {
+	It("should flag vm with USB enabled", func() {
 		var vm = newVM()
 		usb := ovirtsdk.Usb{}
+		usb.SetEnabled(true)
 		vm.SetUsb(&usb)
 
 		failures := ValidateVM(vm)


### PR DESCRIPTION
During manual testing it turned out that:
- disk without interface attribute can happen;
- usb needs to have `enabled` flag checked, not presence of the usb itself;

Signed-off-by: Jakub Dzon <jdzon@redhat.com>