### PR TITLE
Add mapper module

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -168,7 +168,8 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 	}
 
 	// Define VM spec
-	vmSpec := provider.CreateVMSpec(instance)
+	mapper := provider.CreateMapper()
+	vmSpec := mapper.MapVM(instance.Spec.TargetVMName)
 
 	// Set VirtualMachineImport instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, vmSpec, r.scheme); err != nil {
@@ -199,7 +200,7 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 		}
 
 		// Import disks:
-		dvs := provider.CreateDataVolumeMap(instance.Namespace)
+		dvs := mapper.MapDisks()
 		for _, dv := range dvs {
 			_, err := r.kubeClient.CdiClient().CdiV1alpha1().DataVolumes(instance.Namespace).Create(&dv)
 			if err != nil {

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -1,0 +1,210 @@
+package mapper
+
+import (
+	"strconv"
+
+	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
+	provider "github.com/kubevirt/vm-import-operator/pkg/providers"
+	"github.com/kubevirt/vm-import-operator/pkg/utils"
+	ovirtsdk "github.com/ovirt/go-ovirt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+)
+
+const (
+	cdiAPIVersion = "cdi.kubevirt.io/v1alpha1"
+)
+
+var biosMapping = map[string]*kubevirtv1.Bootloader{
+	"q35_sea_bios":    &kubevirtv1.Bootloader{BIOS: &kubevirtv1.BIOS{}},
+	"q35_secure_boot": &kubevirtv1.Bootloader{BIOS: &kubevirtv1.BIOS{}},
+	"q35_ovmf":        &kubevirtv1.Bootloader{EFI: &kubevirtv1.EFI{}},
+}
+
+var archMapping = map[string]string{
+	"x86_64": "q35",
+}
+
+// OvirtMapper is struct that holds attributes needed to map oVirt VM to kubevirt VM
+type OvirtMapper struct {
+	vm        *ovirtsdk.Vm
+	mappings  *v2vv1alpha1.OvirtMappings
+	creds     provider.DataVolumeCredentials
+	namespace string
+}
+
+// NewOvirtMapper create ovirt mapper object
+func NewOvirtMapper(vm *ovirtsdk.Vm, mappings *v2vv1alpha1.OvirtMappings, creds provider.DataVolumeCredentials, namespace string) *OvirtMapper {
+	return &OvirtMapper{
+		vm:        vm,
+		mappings:  mappings,
+		creds:     creds,
+		namespace: namespace,
+	}
+}
+
+// MapVM map oVirt API VM definition to kubevirt VM definition
+func (o *OvirtMapper) MapVM(targetVMName *string) *kubevirtv1.VirtualMachine {
+	vmSpec := kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.namespace,
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{},
+				},
+			},
+		},
+	}
+
+	// Map name
+	vmName, shouldGenerate := o.resolveVMName(targetVMName, o.vm)
+	if shouldGenerate {
+		vmSpec.ObjectMeta.GenerateName = "ovirt-"
+	} else {
+		vmSpec.ObjectMeta.Name = vmName
+	}
+
+	// Map CPU
+	vmSpec.Spec.Template.Spec.Domain.CPU = o.mapCPU()
+
+	// Map bios
+	vmSpec.Spec.Template.Spec.Domain.Firmware = o.mapFirmware()
+
+	// Map machine type
+	vmSpec.Spec.Template.Spec.Domain.Machine = *o.mapArchitecture()
+
+	return &vmSpec
+}
+
+// MapDisks map the oVirt VM disks to the map of CDI DataVolumes specification, where
+// map id is the id of the oVirt disk
+func (o *OvirtMapper) MapDisks() map[string]cdiv1.DataVolume {
+	diskAttachments, _ := o.vm.DiskAttachments()
+	dvs := make(map[string]cdiv1.DataVolume, len(diskAttachments.Slice()))
+
+	for _, diskAttachment := range diskAttachments.Slice() {
+		attachID, _ := diskAttachment.Id()
+		disk, _ := diskAttachment.Disk()
+		diskID, _ := disk.Id()
+		sdClass := o.getStorageClassForDisk(disk, o.mappings)
+		diskSize, _ := disk.ProvisionedSize()
+		quantity, _ := resource.ParseQuantity(strconv.FormatInt(diskSize, 10))
+
+		dvs[attachID] = cdiv1.DataVolume{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: cdiAPIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      attachID,
+				Namespace: o.namespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: cdiv1.DataVolumeSource{
+					Imageio: &cdiv1.DataVolumeSourceImageIO{
+						URL:           o.creds.URL,
+						DiskID:        diskID,
+						SecretRef:     o.creds.SecretName,
+						CertConfigMap: o.creds.ConfigMapName,
+					},
+				},
+				PVC: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: quantity,
+						},
+					},
+				},
+			},
+		}
+		if sdClass != nil {
+			dvs[attachID].Spec.PVC.StorageClassName = sdClass
+		}
+	}
+	return dvs
+}
+
+func (o *OvirtMapper) resolveVMName(targetVMName *string, vm *ovirtsdk.Vm) (string, bool) {
+	if targetVMName != nil {
+		return *targetVMName, false
+	}
+
+	name, ok := vm.Name()
+	if !ok {
+		return "", true
+	}
+
+	name, err := utils.NormalizeName(name)
+	if err != nil {
+		// TODO: should name validation be included in condition ?
+		return "", true
+	}
+
+	return name, false
+}
+
+func (o *OvirtMapper) getStorageClassForDisk(disk *ovirtsdk.Disk, mappings *v2vv1alpha1.OvirtMappings) *string {
+	sds, _ := disk.StorageDomains()
+	sd := sds.Slice()[0]
+	for _, mapping := range *mappings.StorageMappings {
+		if mapping.Source.Name != nil {
+			if name, _ := sd.Name(); name == *mapping.Source.Name {
+				return &mapping.Target.Name
+			}
+		}
+
+		if mapping.Source.ID != nil {
+			if id, _ := sd.Id(); id == *mapping.Source.ID {
+				return &mapping.Target.Name
+			}
+		}
+	}
+
+	// Use default storage class:
+	return nil
+}
+
+func (o *OvirtMapper) mapArchitecture() *kubevirtv1.Machine {
+	arch, _ := o.vm.MustCpu().Architecture()
+	return &kubevirtv1.Machine{
+		Type: archMapping[string(arch)],
+	}
+}
+
+func (o *OvirtMapper) mapFirmware() *kubevirtv1.Firmware {
+	bios, _ := o.vm.Bios()
+	biosType, _ := bios.Type()
+	bootloader, ok := biosMapping[string(biosType)]
+	if ok {
+		bootloader = &kubevirtv1.Bootloader{BIOS: &kubevirtv1.BIOS{}}
+	}
+	return &kubevirtv1.Firmware{
+		Bootloader: bootloader,
+	}
+}
+
+func (o *OvirtMapper) mapCPU() *kubevirtv1.CPU {
+	cpu := kubevirtv1.CPU{}
+	if cpuDef, available := o.vm.Cpu(); available {
+		if topology, available := cpuDef.Topology(); available {
+			if cores, available := topology.Cores(); available {
+				cpu.Cores = uint32(cores)
+			}
+			if sockets, available := topology.Sockets(); available {
+				cpu.Sockets = uint32(sockets)
+			}
+			if threads, available := topology.Threads(); available {
+				cpu.Threads = uint32(threads)
+			}
+		}
+	}
+
+	return &cpu
+}

--- a/pkg/providers/ovirt/mapper/mapper_suite_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_suite_test.go
@@ -1,0 +1,13 @@
+package mapper_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMapper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mapper Suite")
+}

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -1,0 +1,61 @@
+package mapper_test
+
+import (
+	provider "github.com/kubevirt/vm-import-operator/pkg/providers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	ovirtsdk "github.com/ovirt/go-ovirt"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+
+	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/mapper"
+)
+
+var targetVMName = "myvm"
+
+var _ = Describe("Test mapping virtual machine attributes", func() {
+	var (
+		vm     *ovirtsdk.Vm
+		vmSpec *kubevirtv1.VirtualMachine
+	)
+
+	BeforeEach(func() {
+		vm = createVM()
+		mapper := mapper.NewOvirtMapper(vm, nil, provider.DataVolumeCredentials{}, "")
+		vmSpec = mapper.MapVM(&targetVMName)
+	})
+
+	It("For name", func() {
+		Expect(vmSpec.Name).To(Equal(vm.MustName()))
+	})
+
+	It("For CPU topology", func() {
+		vmTopology := vm.MustCpu().MustTopology()
+		vmSpecCPU := vmSpec.Spec.Template.Spec.Domain.CPU
+		Expect(vmSpecCPU.Cores).To(Equal(uint32(vmTopology.MustCores())))
+		Expect(vmSpecCPU.Sockets).To(Equal(uint32(vmTopology.MustSockets())))
+		Expect(vmSpecCPU.Threads).To(Equal(uint32(vmTopology.MustThreads())))
+	})
+
+	It("For BIOS", func() {
+		bootloader := vmSpec.Spec.Template.Spec.Domain.Firmware.Bootloader.BIOS
+		Expect(bootloader).ToNot(BeNil())
+	})
+})
+
+func createVM() *ovirtsdk.Vm {
+	return ovirtsdk.NewVmBuilder().
+		Name("myvm").
+		Bios(
+			ovirtsdk.NewBiosBuilder().
+				Type(ovirtsdk.BIOSTYPE_Q35_SEA_BIOS).MustBuild()).
+		Cpu(
+			ovirtsdk.NewCpuBuilder().
+				Topology(
+					ovirtsdk.NewCpuTopologyBuilder().
+						Cores(1).
+						Sockets(2).
+						Threads(4).
+						MustBuild()).
+				MustBuild()).
+		MustBuild()
+}

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -15,10 +15,15 @@ type Provider interface {
 	PrepareResourceMapping(*v2vv1alpha1.ResourceMappingSpec, v2vv1alpha1.VirtualMachineImportSourceSpec)
 	Validate() error
 	StopVM() error
-	CreateVMSpec(vmImport *v2vv1alpha1.VirtualMachineImport) *kubevirtv1.VirtualMachine
 	GetDataVolumeCredentials() DataVolumeCredentials
-	CreateDataVolumeMap(namespace string) map[string]cdiv1.DataVolume
 	UpdateVM(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume)
+	CreateMapper() Mapper
+}
+
+// Mapper is interface to be used for mapping external VM to kubevirt VM
+type Mapper interface {
+	MapVM(targetVMName *string) *kubevirtv1.VirtualMachine
+	MapDisks() map[string]cdiv1.DataVolume
 }
 
 // DataVolumeCredentials defines the credentials required for creating a data volume


### PR DESCRIPTION
This PR add new mapper module, which contains functionality to map
external VM to kubevirt VM.

This is just refactoring code. No new functionality. Functionality will go in another PR(s).

Signed-off-by: Ondra Machacek <omachace@redhat.com>