### PR TITLE
Validator tests use public api

### DIFF
--- a/pkg/providers/ovirt/validation/validators/network-mapping-validator.go
+++ b/pkg/providers/ovirt/validation/validators/network-mapping-validator.go
@@ -3,8 +3,6 @@ package validators
 import (
 	"fmt"
 
-	"kubevirt.io/client-go/kubecli"
-
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
@@ -21,12 +19,10 @@ type NetworkMappingValidator struct {
 	provider NetworkAttachmentDefinitionProvider
 }
 
-//NewNetworkMappingValidator creates new NetworkMappingValidator that will use provided KubevirtClient
-func NewNetworkMappingValidator(kubevirt kubecli.KubevirtClient) NetworkMappingValidator {
+//NewNetworkMappingValidator creates new NetworkMappingValidator that will use given provider
+func NewNetworkMappingValidator(provider NetworkAttachmentDefinitionProvider) NetworkMappingValidator {
 	return NetworkMappingValidator{
-		provider: &NetworkAttachmentDefinitions{
-			Client: kubevirt.NetworkClient(),
-		},
+		provider: provider,
 	}
 }
 

--- a/pkg/providers/ovirt/validation/validators/network-mapping-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/network-mapping-validator_test.go
@@ -1,8 +1,9 @@
-package validators
+package validators_test
 
 import (
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
+	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/validation/validators"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -28,9 +29,7 @@ var (
 )
 
 var _ = Describe("Validating Network mapping", func() {
-	validator := NetworkMappingValidator{
-		provider: &mockNetAttachDefProvider{},
-	}
+	validator := validators.NewNetworkMappingValidator(&mockNetAttachDefProvider{})
 	BeforeEach(func() {
 		findNetAttachDefMock = func(name string) (*netv1.NetworkAttachmentDefinition, error) {
 			netAttachDef := netv1.NetworkAttachmentDefinition{
@@ -63,7 +62,7 @@ var _ = Describe("Validating Network mapping", func() {
 		failures := validator.ValidateNetworkMapping(nics, &mapping, namespace)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(NetworkMappingID))
+		Expect(failures[0].ID).To(Equal(validators.NetworkMappingID))
 	},
 		table.Entry("Vnic profile network with no mapping", createNic(&networkName, &networkID), nil, nil),
 		table.Entry("Vnic profile network with ID mismatch", createNic(&networkName, &networkID), nil, &wrongNetworkID),
@@ -207,7 +206,7 @@ var _ = Describe("Validating Network mapping", func() {
 		failures := validator.ValidateNetworkMapping(nics, &mapping, namespace)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(NetworkTargetID))
+		Expect(failures[0].ID).To(Equal(validators.NetworkTargetID))
 	})
 	It("should reject genie type", func() {
 		nics := []*ovirtsdk.Nic{
@@ -230,7 +229,7 @@ var _ = Describe("Validating Network mapping", func() {
 		failures := validator.ValidateNetworkMapping(nics, &mapping, namespace)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(NetworkTypeID))
+		Expect(failures[0].ID).To(Equal(validators.NetworkTypeID))
 	})
 	It("should reject nil mapping", func() {
 		nics := []*ovirtsdk.Nic{
@@ -240,7 +239,7 @@ var _ = Describe("Validating Network mapping", func() {
 		failures := validator.ValidateNetworkMapping(nics, nil, namespace)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(NetworkMappingID))
+		Expect(failures[0].ID).To(Equal(validators.NetworkMappingID))
 	})
 	It("should accept nil mapping and one nic with no vnic profile", func() {
 		nic := ovirtsdk.Nic{}

--- a/pkg/providers/ovirt/validation/validators/nic-validator.go
+++ b/pkg/providers/ovirt/validation/validators/nic-validator.go
@@ -12,6 +12,7 @@ import (
 // InterfaceModelMapping defines mapping of NIC device models between oVirt and kubevirt domains
 var InterfaceModelMapping = map[string]string{"e1000": "e1000", "rtl8139": "rtl8139", "virtio": "virtio"}
 
+// ValidateNics validates given slice of NICs
 func ValidateNics(nics []*ovirtsdk.Nic) []ValidationFailure {
 	var failures []ValidationFailure
 	for _, nic := range nics {

--- a/pkg/providers/ovirt/validation/validators/storage-mapping-validator.go
+++ b/pkg/providers/ovirt/validation/validators/storage-mapping-validator.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/storage/v1"
-	"kubevirt.io/client-go/kubecli"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
@@ -21,12 +20,10 @@ type StorageMappingValidator struct {
 	provider StorageClassProvider
 }
 
-// NewStorageMappingValidator creates new StorageMappingValidator that will use provided KubevirtClient
-func NewStorageMappingValidator(kubevirt kubecli.KubevirtClient) StorageMappingValidator {
+// NewStorageMappingValidator creates new StorageMappingValidator that will use given provider
+func NewStorageMappingValidator(provider StorageClassProvider) StorageMappingValidator {
 	return StorageMappingValidator{
-		provider: &StorageClasses{
-			Client: kubevirt.StorageV1().StorageClasses(),
-		},
+		provider: provider,
 	}
 }
 

--- a/pkg/providers/ovirt/validation/validators/storage-mapping-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/storage-mapping-validator_test.go
@@ -1,9 +1,10 @@
-package validators
+package validators_test
 
 import (
 	"fmt"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
+	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/validation/validators"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -23,9 +24,7 @@ var (
 )
 
 var _ = Describe("Validating Storage mapping", func() {
-	validator := StorageMappingValidator{
-		provider: &mockStorageClassProvider{},
-	}
+	validator := validators.NewStorageMappingValidator(&mockStorageClassProvider{})
 	BeforeEach(func() {
 		findStorageClassMock = func() (*v1.StorageClass, error) {
 			sc := v1.StorageClass{
@@ -57,7 +56,7 @@ var _ = Describe("Validating Storage mapping", func() {
 		failures := validator.ValidateStorageMapping(das, &mapping)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(StorageMappingID))
+		Expect(failures[0].ID).To(Equal(validators.StorageMappingID))
 	},
 		table.Entry("No mapping", createDomain(&domainName, &domainID), nil, nil),
 		table.Entry("ID mismatch", createDomain(&domainName, &domainID), nil, &wrongDomainID),
@@ -116,7 +115,7 @@ var _ = Describe("Validating Storage mapping", func() {
 		failures := validator.ValidateStorageMapping(das, &mapping)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(StorageTargetID))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetID))
 	})
 	It("should reject nil mapping", func() {
 		sd := createDomain(&domainName, &domainID)
@@ -128,7 +127,7 @@ var _ = Describe("Validating Storage mapping", func() {
 		failures := validator.ValidateStorageMapping(das, nil)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(StorageMappingID))
+		Expect(failures[0].ID).To(Equal(validators.StorageMappingID))
 	})
 })
 

--- a/pkg/providers/ovirt/validation/validators/storage-validator.go
+++ b/pkg/providers/ovirt/validation/validators/storage-validator.go
@@ -10,21 +10,22 @@ import (
 // DiskInterfaceModelMapping defines mapping of disk interface models between oVirt and kubevirt domains
 var DiskInterfaceModelMapping = map[string]string{"sata": "sata", "virtio_scsi": "virtio", "virtio": "virtio"}
 
-//DiskInterfaceOwner defines means of getting interface of a storage entity
-type DiskInterfaceOwner interface {
+// diskInterfaceOwner defines means of getting interface of a storage entity
+type diskInterfaceOwner interface {
 	Interface() (ovirtsdk.DiskInterface, bool)
 }
 
-//DiskLogicalNameOwner defines means of getting logical name of a storage entity
-type DiskLogicalNameOwner interface {
+// diskLogicalNameOwner defines means of getting logical name of a storage entity
+type diskLogicalNameOwner interface {
 	LogicalName() (string, bool)
 }
 
-//UsesScsiReservationOwner defines means of getting uses scsi reservation flag value of a storage entity
-type UsesScsiReservationOwner interface {
+// usesScsiReservationOwner defines means of getting uses scsi reservation flag value of a storage entity
+type usesScsiReservationOwner interface {
 	UsesScsiReservation() (bool, bool)
 }
 
+// ValidateDiskAttachments validates disk attachments
 func ValidateDiskAttachments(diskAttachments []*ovirtsdk.DiskAttachment) []ValidationFailure {
 	var failures []ValidationFailure
 	for _, da := range diskAttachments {
@@ -32,6 +33,7 @@ func ValidateDiskAttachments(diskAttachments []*ovirtsdk.DiskAttachment) []Valid
 	}
 	return failures
 }
+
 func validateDiskAttachment(diskAttachment *ovirtsdk.DiskAttachment) []ValidationFailure {
 	var results []ValidationFailure
 	var attachmentID = ""
@@ -105,7 +107,7 @@ func isValidDiskInterface(disk *ovirtsdk.Disk, diskID string) (ValidationFailure
 	return isValidStorageInterface(disk, diskID, DiskInterfaceID)
 }
 
-func isValidStorageInterface(diskAttachment DiskInterfaceOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
+func isValidStorageInterface(diskAttachment diskInterfaceOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
 	if iface, ok := diskAttachment.Interface(); ok {
 		if _, found := DiskInterfaceModelMapping[string(iface)]; !found {
 			return ValidationFailure{
@@ -126,7 +128,7 @@ func isValidDiskLogicalName(disk *ovirtsdk.Disk, diskID string) (ValidationFailu
 	return isValidStorageLogicalName(disk, diskID, DiskLogicalNameID)
 }
 
-func isValidStorageLogicalName(logicalNameOwner DiskLogicalNameOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
+func isValidStorageLogicalName(logicalNameOwner diskLogicalNameOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
 	if logicalName, ok := logicalNameOwner.LogicalName(); ok {
 		return ValidationFailure{
 			ID:      checkID,
@@ -154,7 +156,7 @@ func isValidDiskUsesScsiReservation(disk *ovirtsdk.Disk, diskID string) (Validat
 	return isValidStorageUsesScsiReservation(disk, diskID, DiskUsesScsiReservationID)
 }
 
-func isValidStorageUsesScsiReservation(owner UsesScsiReservationOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
+func isValidStorageUsesScsiReservation(owner usesScsiReservationOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
 	if sr, ok := owner.UsesScsiReservation(); ok && sr {
 		return ValidationFailure{
 			ID:      checkID,

--- a/pkg/providers/ovirt/validation/validators/validator-wrapper.go
+++ b/pkg/providers/ovirt/validation/validators/validator-wrapper.go
@@ -14,9 +14,15 @@ type ValidatorWrapper struct {
 
 // NewValidatorWrapper creates new, configured ValidatorWrapper
 func NewValidatorWrapper(kubevirt kubecli.KubevirtClient) *ValidatorWrapper {
+	netAttachDefProvider := NetworkAttachmentDefinitions{
+		Client: kubevirt.NetworkClient(),
+	}
+	storageClassesProvider := StorageClasses{
+		Client: kubevirt.StorageV1().StorageClasses(),
+	}
 	return &ValidatorWrapper{
-		networkMappingValidator: NewNetworkMappingValidator(kubevirt),
-		storageMappingValidator: NewStorageMappingValidator(kubevirt),
+		networkMappingValidator: NewNetworkMappingValidator(&netAttachDefProvider),
+		storageMappingValidator: NewStorageMappingValidator(&storageClassesProvider),
 	}
 }
 

--- a/pkg/providers/ovirt/validation/validators/vm-validator.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator.go
@@ -10,6 +10,7 @@ import (
 // BiosTypeMapping defines mapping of BIOS types between oVirt and kubevirt domains
 var BiosTypeMapping = map[string]string{"q35_ovmf": "efi", "q35_sea_bios": "bios", "q35_secure_boot": "bios"}
 
+// ValidateVM validates given VM
 func ValidateVM(vm *ovirtsdk.Vm) []ValidationFailure {
 	var results = isValidBios(vm)
 	results = append(results, isValidCPU(vm)...)

--- a/pkg/providers/ovirt/validation/validators/vm-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator_test.go
@@ -1,6 +1,7 @@
-package validators
+package validators_test
 
 import (
+	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/validation/validators"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -11,7 +12,7 @@ var _ = Describe("Validating VM", func() {
 	It("should accept vm ", func() {
 		var vm = newVM()
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(BeEmpty())
 	})
@@ -22,30 +23,30 @@ var _ = Describe("Validating VM", func() {
 		bootMenu.SetEnabled(true)
 		bios.SetBootMenu(&bootMenu)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMBiosBootMenuID))
+		Expect(failures[0].ID).To(Equal(validators.VMBiosBootMenuID))
 	})
 	It("should flag vm with no bios type ", func() {
 		var vm = newVM()
 		bios := ovirtsdk.Bios{}
 		vm.SetBios(&bios)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMBiosTypeID))
+		Expect(failures[0].ID).To(Equal(validators.VMBiosTypeID))
 	})
 	It("should flag vm with q35_secure_boot bios ", func() {
 		var vm = newVM()
 		bios := vm.MustBios()
 		bios.SetType("q35_secure_boot")
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMBiosTypeQ35SecureBootID))
+		Expect(failures[0].ID).To(Equal(validators.VMBiosTypeQ35SecureBootID))
 	})
 	It("should flag vm with s390x CPU ", func() {
 		var vm = newVM()
@@ -53,19 +54,19 @@ var _ = Describe("Validating VM", func() {
 		cpu.SetArchitecture("s390x")
 		vm.SetCpu(&cpu)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMCpuArchitectureID))
+		Expect(failures[0].ID).To(Equal(validators.VMCpuArchitectureID))
 	})
 	table.DescribeTable("should flag CPU with illegal pinning for", func(pins []*ovirtsdk.VcpuPin) {
 		vm := newVM()
 		vm.MustCpu().MustCpuTune().MustVcpuPins().SetSlice(pins)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMCpuTuneID))
+		Expect(failures[0].ID).To(Equal(validators.VMCpuTuneID))
 	},
 		table.Entry("duplicate pins", []*ovirtsdk.VcpuPin{newCPUPin(0, "0"), newCPUPin(1, "0")}),
 		table.Entry("cpu range", []*ovirtsdk.VcpuPin{newCPUPin(0, "0-1"), newCPUPin(1, "0-1")}),
@@ -76,10 +77,10 @@ var _ = Describe("Validating VM", func() {
 		var vm = newVM()
 		vm.SetCpuShares(1024)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMCpuSharesID))
+		Expect(failures[0].ID).To(Equal(validators.VMCpuSharesID))
 	})
 	It("should flag vm with custom properties ", func() {
 		var vm = newVM()
@@ -89,10 +90,10 @@ var _ = Describe("Validating VM", func() {
 		cps.SetSlice(properties)
 		vm.SetCustomProperties(&cps)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMCustomPropertiesID))
+		Expect(failures[0].ID).To(Equal(validators.VMCustomPropertiesID))
 	})
 	It("should flag vm with spice display ", func() {
 		var vm = newVM()
@@ -100,28 +101,28 @@ var _ = Describe("Validating VM", func() {
 		display.SetType("spice")
 		vm.SetDisplay(&display)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMDisplayTypeID))
+		Expect(failures[0].ID).To(Equal(validators.VMDisplayTypeID))
 	})
 	It("should flag vm with illegal images ", func() {
 		var vm = newVM()
 		vm.SetHasIllegalImages(true)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMHasIllegalImagesID))
+		Expect(failures[0].ID).To(Equal(validators.VMHasIllegalImagesID))
 	})
 	It("should flag vm with high availability priority ", func() {
 		var vm = newVM()
 		vm.MustHighAvailability().SetPriority(1)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMHighAvailabilityPriorityID))
+		Expect(failures[0].ID).To(Equal(validators.VMHighAvailabilityPriorityID))
 	})
 	It("should flag vm with IO Threads configured ", func() {
 		var vm = newVM()
@@ -129,10 +130,10 @@ var _ = Describe("Validating VM", func() {
 		io.SetThreads(4)
 		vm.SetIo(&io)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMIoThreadsID))
+		Expect(failures[0].ID).To(Equal(validators.VMIoThreadsID))
 	})
 	It("should flag vm with memory balooning ", func() {
 		var vm = newVM()
@@ -140,10 +141,10 @@ var _ = Describe("Validating VM", func() {
 		memPolicy.SetBallooning(true)
 		vm.SetMemoryPolicy(&memPolicy)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMMemoryPolicyBallooningID))
+		Expect(failures[0].ID).To(Equal(validators.VMMemoryPolicyBallooningID))
 	})
 	It("should flag vm with guaranteed memory ", func() {
 		var vm = newVM()
@@ -151,10 +152,10 @@ var _ = Describe("Validating VM", func() {
 		memPolicy.SetGuaranteed(1024)
 		vm.SetMemoryPolicy(&memPolicy)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMMemoryPolicyGuaranteedID))
+		Expect(failures[0].ID).To(Equal(validators.VMMemoryPolicyGuaranteedID))
 	})
 	It("should flag vm with overcommit percent ", func() {
 		var vm = newVM()
@@ -164,56 +165,56 @@ var _ = Describe("Validating VM", func() {
 		memPolicy.SetOverCommit(&memOverCommit)
 		vm.SetMemoryPolicy(&memPolicy)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMMemoryPolicyOvercommitPercentID))
+		Expect(failures[0].ID).To(Equal(validators.VMMemoryPolicyOvercommitPercentID))
 	})
 	It("should flag vm with migration options ", func() {
 		var vm = newVM()
 		migration := ovirtsdk.MigrationOptions{}
 		vm.SetMigration(&migration)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMMigrationID))
+		Expect(failures[0].ID).To(Equal(validators.VMMigrationID))
 	})
 	It("should flag vm with migration downtime ", func() {
 		var vm = newVM()
 		vm.SetMigrationDowntime(5)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMMigrationDowntimeID))
+		Expect(failures[0].ID).To(Equal(validators.VMMigrationDowntimeID))
 	})
 	It("should flag vm with NUMA tune mode ", func() {
 		var vm = newVM()
 		vm.SetNumaTuneMode("strict")
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMNumaTuneModeID))
+		Expect(failures[0].ID).To(Equal(validators.VMNumaTuneModeID))
 	})
 	It("should flag vm with origin == kubevirt ", func() {
 		var vm = newVM()
 		vm.SetOrigin("kubevirt")
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMOriginID))
+		Expect(failures[0].ID).To(Equal(validators.VMOriginID))
 	})
 	table.DescribeTable("should flag VM with illegal random number generator source", func(source string) {
 		vm := newVM()
 		vm.MustRngDevice().SetSource(ovirtsdk.RngSource(source))
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMRngDeviceSourceID))
+		Expect(failures[0].ID).To(Equal(validators.VMRngDeviceSourceID))
 	},
 		table.Entry("hwrng", "hwrng"),
 		table.Entry("random", "random"),
@@ -225,37 +226,37 @@ var _ = Describe("Validating VM", func() {
 		var vm = newVM()
 		vm.SetSoundcardEnabled(true)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMSoundcardEnabledID))
+		Expect(failures[0].ID).To(Equal(validators.VMSoundcardEnabledID))
 	})
 	It("should flag vm with start paused enabled", func() {
 		var vm = newVM()
 		vm.SetStartPaused(true)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMStartPausedID))
+		Expect(failures[0].ID).To(Equal(validators.VMStartPausedID))
 	})
 	It("should flag vm with storage error resume behaviour specified", func() {
 		var vm = newVM()
 		vm.SetStorageErrorResumeBehaviour("auto_resume")
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMStorageErrorResumeBehaviourID))
+		Expect(failures[0].ID).To(Equal(validators.VMStorageErrorResumeBehaviourID))
 	})
 	It("should flag vm with tunnel migration enabled", func() {
 		var vm = newVM()
 		vm.SetTunnelMigration(true)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMTunnelMigrationID))
+		Expect(failures[0].ID).To(Equal(validators.VMTunnelMigrationID))
 	})
 	It("should flag vm with USB enabled", func() {
 		var vm = newVM()
@@ -263,20 +264,20 @@ var _ = Describe("Validating VM", func() {
 		usb.SetEnabled(true)
 		vm.SetUsb(&usb)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMUsbID))
+		Expect(failures[0].ID).To(Equal(validators.VMUsbID))
 	})
 	It("should flag vm with spice console configured", func() {
 		var vm = newVM()
 		consoles := []*ovirtsdk.GraphicsConsole{newGraphicsConsole("spice"), newGraphicsConsole("vnc")}
 		vm.MustGraphicsConsoles().SetSlice(consoles)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMGraphicConsolesID))
+		Expect(failures[0].ID).To(Equal(validators.VMGraphicConsolesID))
 	})
 	It("should flag vm's host devices", func() {
 		var vm = newVM()
@@ -285,10 +286,10 @@ var _ = Describe("Validating VM", func() {
 		hostDevices.SetSlice(devices)
 		vm.SetHostDevices(&hostDevices)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMHostDevicesID))
+		Expect(failures[0].ID).To(Equal(validators.VMHostDevicesID))
 	})
 	It("should flag vm's reported devices", func() {
 		var vm = newVM()
@@ -297,10 +298,10 @@ var _ = Describe("Validating VM", func() {
 		reportedDevices.SetSlice(devices)
 		vm.SetReportedDevices(&reportedDevices)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMReportedDevicesID))
+		Expect(failures[0].ID).To(Equal(validators.VMReportedDevicesID))
 	})
 	It("should flag vm with quota", func() {
 		var vm = newVM()
@@ -308,10 +309,10 @@ var _ = Describe("Validating VM", func() {
 		quota.SetId("quota_id")
 		vm.SetQuota(&quota)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMQuotaID))
+		Expect(failures[0].ID).To(Equal(validators.VMQuotaID))
 	})
 	It("should flag illegal watchdog - diag288", func() {
 		var vm = newVM()
@@ -319,10 +320,10 @@ var _ = Describe("Validating VM", func() {
 		watchdog.SetModel("diag288")
 		vm.MustWatchdogs().SetSlice([]*ovirtsdk.Watchdog{&watchdog})
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMWatchdogsID))
+		Expect(failures[0].ID).To(Equal(validators.VMWatchdogsID))
 	})
 	It("should flag CD ROM with image stored in non-data domain", func() {
 		var vm = newVM()
@@ -336,10 +337,10 @@ var _ = Describe("Validating VM", func() {
 		cdroms := []*ovirtsdk.Cdrom{&cdrom}
 		vm.MustCdroms().SetSlice(cdroms)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMCdromsID))
+		Expect(failures[0].ID).To(Equal(validators.VMCdromsID))
 	})
 	It("should flag floppies", func() {
 		var vm = newVM()
@@ -349,10 +350,10 @@ var _ = Describe("Validating VM", func() {
 		floppySlice.SetSlice(floppies)
 		vm.SetFloppies(&floppySlice)
 
-		failures := ValidateVM(vm)
+		failures := validators.ValidateVM(vm)
 
 		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(VMFloppiesID))
+		Expect(failures[0].ID).To(Equal(validators.VMFloppiesID))
 	})
 })
 


### PR DESCRIPTION
This PR refactors `validators` package tests to use only public API. As a side-effect the API and packages' dependencies get a little cleaner.