### PR TITLE
Update watch events filtering

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -103,6 +104,12 @@ func main() {
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	//Add cdi scheme
+	if err := cdiv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This patch update the watch events filtering as follows:

1) For the VMImport CR we ignore update events if import succeded.
2) For the VM resource we ignore all Create/Update events.
3) For the DV resource we ignore all Create/Update events.

We ignore the update events, because import process is one time
operation and we ignore later updates to the CR.

Signed-off-by: Ondra Machacek <omachace@redhat.com>