### PR TITLE
Add DiskMappings for specific disk mappings

### DIFF
--- a/deploy/crds/v2v_v1alpha1_virtualmachineimport_cr.yaml
+++ b/deploy/crds/v2v_v1alpha1_virtualmachineimport_cr.yaml
@@ -27,6 +27,16 @@ spec:
             target:
               name: pod
             type: pod
+        storageMappings:
+          - source:
+              name: storage_domain_1
+            target:
+              name: storage_class_1
+        diskMappings: # specifies per-disk placement on storage class
+          - source:
+              id: 8181ecc1-5db8-4193-9c92-3ddab3be7b05
+            target:
+              name: storage_class_1
 status:
   targetVmName: myvm # the name of the created virtual machine
   conditions:

--- a/deploy/crds/v2v_v1alpha1_virtualmachineimport_crd.yaml
+++ b/deploy/crds/v2v_v1alpha1_virtualmachineimport_crd.yaml
@@ -90,6 +90,8 @@ spec:
                       type: array
                     storageMappings:
                       type: array
+                    diskMappings:
+                      type: array
         status:
           properties:
   version: v1alpha1

--- a/pkg/apis/v2v/v1alpha1/resourcemapping_types.go
+++ b/pkg/apis/v2v/v1alpha1/resourcemapping_types.go
@@ -24,8 +24,16 @@ type OvirtMappings struct {
 	// +optional
 	NetworkMappings *[]ResourceMappingItem `json:"networkMappings,omitempty"`
 
+	// StorageMappings defines the mapping of storage domains to storage classes
 	// +optional
 	StorageMappings *[]ResourceMappingItem `json:"storageMappings,omitempty"`
+
+	// DiskMappings defines the mapping of disks to storage classes
+	// DiskMappings.Source.ID represents the disk ID on ovirt (as opposed to disk-attachment ID)
+	// DiskMappings.Source.Name represents the disk alias on ovirt
+	// DiskMappings is respected only when provided in context of a single VM import within VirtualMachineImport
+	// +optional
+	DiskMappings *[]ResourceMappingItem `json:"diskMappings,omitempty"`
 }
 
 // Source defines how to identify a resource on the provider, either by ID or by name

--- a/pkg/apis/v2v/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v2v/v1alpha1/zz_generated.deepcopy.go
@@ -70,6 +70,17 @@ func (in *OvirtMappings) DeepCopyInto(out *OvirtMappings) {
 			}
 		}
 	}
+	if in.DiskMappings != nil {
+		in, out := &in.DiskMappings, &out.DiskMappings
+		*out = new([]ResourceMappingItem)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]ResourceMappingItem, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/providers/ovirt/mappings/merger.go
+++ b/pkg/providers/ovirt/mappings/merger.go
@@ -15,9 +15,13 @@ func MergeMappings(externalMappingSpec *v2vv1alpha1.ResourceMappingSpec, vmiMapp
 	networkMappings := mergeMappings(primaryMappings.NetworkMappings, secondaryMappings.NetworkMappings)
 	storageMappings := mergeMappings(primaryMappings.StorageMappings, secondaryMappings.StorageMappings)
 
+	// diskMappings are expected to be provided only for a specific VM Import CR
+	diskMappings := primaryMappings.DiskMappings
+
 	ovirtMappings := v2vv1alpha1.OvirtMappings{
 		NetworkMappings: networkMappings,
 		StorageMappings: storageMappings,
+		DiskMappings:    diskMappings,
 	}
 	return &ovirtMappings
 }

--- a/pkg/providers/ovirt/validation/mocks_test.go
+++ b/pkg/providers/ovirt/validation/mocks_test.go
@@ -10,7 +10,11 @@ var validateVMMock func(*ovirtsdk.Vm) []validators.ValidationFailure
 var validateNicsMock func([]*ovirtsdk.Nic) []validators.ValidationFailure
 var validateDiskAttachmentsMock func([]*ovirtsdk.DiskAttachment) []validators.ValidationFailure
 var validateNetworkMappingsMock func(nics []*ovirtsdk.Nic, mapping *[]v2vv1alpha1.ResourceMappingItem, crNamespace string) []validators.ValidationFailure
-var validateStorageMappingMock func(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []validators.ValidationFailure
+var validateStorageMappingMock func(
+	attachments []*ovirtsdk.DiskAttachment,
+	storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+	diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+) []validators.ValidationFailure
 
 type mockValidator struct{}
 
@@ -30,6 +34,10 @@ func (v *mockValidator) ValidateNetworkMapping(nics []*ovirtsdk.Nic, mapping *[]
 	return validateNetworkMappingsMock(nics, mapping, crNamespace)
 }
 
-func (v *mockValidator) ValidateStorageMapping(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []validators.ValidationFailure {
-	return validateStorageMappingMock(attachments, mapping)
+func (v *mockValidator) ValidateStorageMapping(
+	attachments []*ovirtsdk.DiskAttachment,
+	storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+	diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+) []validators.ValidationFailure {
+	return validateStorageMappingMock(attachments, storageMapping, diskMapping)
 }

--- a/pkg/providers/ovirt/validation/validators/definitions.go
+++ b/pkg/providers/ovirt/validation/validators/definitions.go
@@ -117,6 +117,10 @@ const (
 	StorageMappingID = CheckID("storage.mapping")
 	// StorageTargetID defines an ID of a check verifying existence of target storage class
 	StorageTargetID = CheckID("storage.target")
+	// DiskMappingID defines an ID of a check verifying that all the required source disks are present in the resource mapping
+	DiskMappingID = CheckID("disk.mapping")
+	// DiskTargetID defines an ID of a check verifying existence of target storage class
+	DiskTargetID = CheckID("disk.target")
 )
 
 // CheckID identifies validation check for Virtual Machine Import

--- a/pkg/providers/ovirt/validation/validators/storage-mapping-validator.go
+++ b/pkg/providers/ovirt/validation/validators/storage-mapping-validator.go
@@ -27,34 +27,66 @@ func NewStorageMappingValidator(provider StorageClassProvider) StorageMappingVal
 	}
 }
 
-// ValidateStorageMapping validates storage domain mapping
-func (v *StorageMappingValidator) ValidateStorageMapping(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []ValidationFailure {
+// ValidateStorageMapping validates storage domain mapping and disk mapping
+func (v *StorageMappingValidator) ValidateStorageMapping(
+	attachments []*ovirtsdk.DiskAttachment,
+	storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+	diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+) []ValidationFailure {
 	var failures []ValidationFailure
 	// Check whether mapping for storage is required and was provided
-	if mapping == nil && len(attachments) > 0 {
+	if storageMapping == nil && diskMapping == nil && len(attachments) > 0 {
 		failures = append(failures, ValidationFailure{
 			ID:      StorageMappingID,
-			Message: "Storage mapping is missing",
+			Message: "Storage and Disk mappings are missing",
 		})
 		return failures
 	}
-	requiredDomains := v.getRequiredStorageDomains(attachments)
-	// Map source id and name to ResourceMappingItem
-	mapByID, mapByName := utils.IndexByIDAndName(mapping)
+	if storageMapping == nil {
+		storageMapping = &[]v2vv1alpha1.ResourceMappingItem{}
+	}
+	if diskMapping == nil {
+		diskMapping = &[]v2vv1alpha1.ResourceMappingItem{}
+	}
+	// requiredDomains holds the domains needed by disks that are not listed in diskMapping
+	requiredDomains := v.getRequiredStorageDomains(attachments, diskMapping)
+	requiredTargetsSet, sourceFailures := v.validateSourceStorageMapping(storageMapping, requiredDomains)
+	failures = append(failures, sourceFailures...)
 
+	storageFailures := v.validateTargetStorageMapping(requiredTargetsSet)
+	failures = append(failures, storageFailures...)
+
+	// check disk mappings for violations
+	if len(*diskMapping) > 0 {
+		disksByStorageClass, missingDiskFailures := v.validateSourcesDiskMapping(diskMapping, attachments)
+		failures = append(failures, missingDiskFailures...)
+
+		// validate disk mapping target storage classes
+		targetFailures := v.validateTargetDiskMapping(disksByStorageClass)
+		failures = append(failures, targetFailures...)
+	}
+
+	return failures
+}
+
+func (v *StorageMappingValidator) validateSourceStorageMapping(
+	storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+	requiredDomains []v2vv1alpha1.Source,
+) ([]v2vv1alpha1.ObjectIdentifier, []ValidationFailure) {
+	var failures []ValidationFailure
+	// Map storageMappings source id and name to ResourceMappingItem
+	mapByID, mapByName := utils.IndexByIDAndName(storageMapping)
 	requiredTargetsSet := make(map[v2vv1alpha1.ObjectIdentifier]bool)
 	// Validate that all vm storage domains are mapped and populate requiredTargetsSet for target existence check
 	for _, domain := range requiredDomains {
 		if domain.ID != nil {
-			item, found := mapByID[*domain.ID]
-			if found {
+			if item, found := mapByID[*domain.ID]; found {
 				requiredTargetsSet[item.Target] = true
 				continue
 			}
 		}
 		if domain.Name != nil {
-			item, found := mapByName[*domain.Name]
-			if found {
+			if item, found := mapByName[*domain.Name]; found {
 				requiredTargetsSet[item.Target] = true
 				continue
 			}
@@ -64,10 +96,17 @@ func (v *StorageMappingValidator) ValidateStorageMapping(attachments []*ovirtsdk
 			Message: fmt.Sprintf("Required source storage domain '%s' lacks mapping", utils.ToLoggableID(domain.ID, domain.Name)),
 		})
 	}
+	requiredTargets := []v2vv1alpha1.ObjectIdentifier{}
+	for t := range requiredTargetsSet {
+		requiredTargets = append(requiredTargets, t)
+	}
+	return requiredTargets, failures
+}
 
-	for className := range requiredTargetsSet {
-		_, err := v.provider.Find(className.Name)
-		if err != nil {
+func (v *StorageMappingValidator) validateTargetStorageMapping(requiredTargetsSet []v2vv1alpha1.ObjectIdentifier) []ValidationFailure {
+	var failures []ValidationFailure
+	for _, className := range requiredTargetsSet {
+		if _, err := v.provider.Find(className.Name); err != nil {
 			failures = append(failures, ValidationFailure{
 				ID:      StorageTargetID,
 				Message: fmt.Sprintf("Storage class %s has not been found. Error: %v", className.Name, err),
@@ -77,25 +116,103 @@ func (v *StorageMappingValidator) ValidateStorageMapping(attachments []*ovirtsdk
 	return failures
 }
 
-func (v *StorageMappingValidator) getRequiredStorageDomains(attachments []*ovirtsdk.DiskAttachment) []v2vv1alpha1.Source {
-	sourcesSet := make(map[v2vv1alpha1.Source]bool)
+// validateSourcesDiskMapping reports failures for missing disks and returns a map of storage domain to disk
+func (v *StorageMappingValidator) validateSourcesDiskMapping(
+	diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+	attachments []*ovirtsdk.DiskAttachment,
+) (map[string]*ovirtsdk.Disk, []ValidationFailure) {
+	var failures []ValidationFailure
+	diskByStorageClass := make(map[string]*ovirtsdk.Disk)
+	disksByID, disksByName := v.getRequiredDisks(attachments)
+	for _, mapping := range *diskMapping {
+		if mapping.Source.ID != nil {
+			if disk, ok := disksByID[*mapping.Source.ID]; ok {
+				diskByStorageClass[mapping.Target.Name] = disk
+				continue
+			}
+		}
+		if mapping.Source.Name != nil {
+			if disk, ok := disksByName[*mapping.Source.Name]; ok {
+				diskByStorageClass[mapping.Target.Name] = disk
+				continue
+			}
+		}
+		failures = append(failures, ValidationFailure{
+			ID:      DiskMappingID,
+			Message: fmt.Sprintf("Source disk %s has not been found for the VM.", utils.ToLoggableID(mapping.Source.ID, mapping.Source.Name)),
+		})
+	}
+	return diskByStorageClass, failures
+}
+
+func (v *StorageMappingValidator) validateTargetDiskMapping(disksByStorageClass map[string]*ovirtsdk.Disk) []ValidationFailure {
+	var failures []ValidationFailure
+	for className, disk := range disksByStorageClass {
+		if _, err := v.provider.Find(className); err != nil {
+			diskID, _ := disk.Id()
+			failures = append(failures, ValidationFailure{
+				ID:      DiskTargetID,
+				Message: fmt.Sprintf("Storage class %s has not been found for disk %s. Error: %v", className, diskID, err),
+			})
+		}
+	}
+	return failures
+}
+
+func (v *StorageMappingValidator) getRequiredDisks(
+	attachments []*ovirtsdk.DiskAttachment,
+) (map[string]*ovirtsdk.Disk, map[string]*ovirtsdk.Disk) {
+	disksByID := make(map[string]*ovirtsdk.Disk)
+	disksByName := make(map[string]*ovirtsdk.Disk)
 	for _, da := range attachments {
 		if disk, ok := da.Disk(); ok {
+			id, okID := disk.Id()
+			if okID {
+				disksByID[id] = disk
+			}
+			name, okName := disk.Alias()
+			if okName {
+				disksByName[name] = disk
+			}
+		}
+	}
+	return disksByID, disksByName
+}
+
+// getRequiredStorageDomains returns a set of required storage domains for storageMappings
+func (v *StorageMappingValidator) getRequiredStorageDomains(
+	attachments []*ovirtsdk.DiskAttachment,
+	diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+) []v2vv1alpha1.Source {
+	// Map diskMapping source id and name to ResourceMappingItem
+	mapByID, mapByName := utils.IndexByIDAndName(diskMapping)
+	storageMappingSourcesSet := make(map[v2vv1alpha1.Source]bool)
+	for _, da := range attachments {
+		if disk, ok := da.Disk(); ok {
+			// skip storage domains for disks specified in diskMapping for later inspection
+			diskID, _ := disk.Id()
+			if _, ok := mapByID[diskID]; ok {
+				continue
+			}
+			diskName, _ := disk.Alias()
+			if _, ok := mapByName[diskName]; ok {
+				continue
+			}
 			if sd, ok := disk.StorageDomain(); ok {
-				if src, ok := v.createSourceStorageDomainIdentifier(sd); ok {
-					sourcesSet[*src] = true
+				if src, ok := createSourceStorageDomainIdentifier(sd); ok {
+					storageMappingSourcesSet[*src] = true
 				}
 			}
 		}
 	}
 	var sources []v2vv1alpha1.Source
-	for source := range sourcesSet {
+	for source := range storageMappingSourcesSet {
 		sources = append(sources, source)
 	}
 	return sources
 }
 
-func (v *StorageMappingValidator) createSourceStorageDomainIdentifier(domain *ovirtsdk.StorageDomain) (*v2vv1alpha1.Source, bool) {
+func createSourceStorageDomainIdentifier(domain *ovirtsdk.StorageDomain) (*v2vv1alpha1.Source, bool) {
 	id, okID := domain.Id()
 	name, okName := domain.Name()
 	if okID || okName {

--- a/pkg/providers/ovirt/validation/validators/validator-wrapper.go
+++ b/pkg/providers/ovirt/validation/validators/validator-wrapper.go
@@ -47,6 +47,10 @@ func (v *ValidatorWrapper) ValidateNetworkMapping(nics []*ovirtsdk.Nic, mapping 
 }
 
 // ValidateStorageMapping wraps storageMappingValidator call
-func (v *ValidatorWrapper) ValidateStorageMapping(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []ValidationFailure {
-	return v.storageMappingValidator.ValidateStorageMapping(attachments, mapping)
+func (v *ValidatorWrapper) ValidateStorageMapping(
+	attachments []*ovirtsdk.DiskAttachment,
+	storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+	diskMappings *[]v2vv1alpha1.ResourceMappingItem,
+) []ValidationFailure {
+	return v.storageMappingValidator.ValidateStorageMapping(attachments, storageMapping, diskMappings)
 }

--- a/pkg/providers/ovirt/validation/vm-import-validation.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation.go
@@ -98,7 +98,11 @@ type Validator interface {
 	ValidateDiskAttachments(diskAttachments []*ovirtsdk.DiskAttachment) []validators.ValidationFailure
 	ValidateNics(nics []*ovirtsdk.Nic) []validators.ValidationFailure
 	ValidateNetworkMapping(nics []*ovirtsdk.Nic, mapping *[]v2vv1alpha1.ResourceMappingItem, crNamespace string) []validators.ValidationFailure
-	ValidateStorageMapping(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []validators.ValidationFailure
+	ValidateStorageMapping(
+		attachments []*ovirtsdk.DiskAttachment,
+		storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+		diskMappings *[]v2vv1alpha1.ResourceMappingItem,
+	) []validators.ValidationFailure
 }
 
 // VirtualMachineImportValidator validates VirtualMachineImport object
@@ -141,7 +145,7 @@ func (validator *VirtualMachineImportValidator) validateMappings(vm *ovirtsdk.Vm
 	}
 	if attachments, ok := vm.DiskAttachments(); ok {
 		das := attachments.Slice()
-		failures = append(failures, validator.Validator.ValidateStorageMapping(das, mappings.StorageMappings)...)
+		failures = append(failures, validator.Validator.ValidateStorageMapping(das, mappings.StorageMappings, mappings.DiskMappings)...)
 	}
 
 	return validator.processMappingValidationFailures(failures, vmiCrName)

--- a/pkg/providers/ovirt/validation/vm-import-validation_test.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation_test.go
@@ -41,9 +41,12 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 		validateNetworkMappingsMock = func(nics []*ovirtsdk.Nic, mapping *[]v2vv1alpha1.ResourceMappingItem, crNamespace string) []validators.ValidationFailure {
 			return []validators.ValidationFailure{}
 		}
-		validateStorageMappingMock = func(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []validators.ValidationFailure {
+		validateStorageMappingMock = func(
+			attachments []*ovirtsdk.DiskAttachment,
+			storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+			diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+		) []validators.ValidationFailure {
 			return []validators.ValidationFailure{}
-
 		}
 	})
 	It("should accept VirtualMachineImport", func() {
@@ -363,7 +366,11 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 		vm := newVM()
 		crName := newNamespacedName()
 		message := "Mapping - boom!"
-		validateStorageMappingMock = func(attachments []*ovirtsdk.DiskAttachment, mapping *[]v2vv1alpha1.ResourceMappingItem) []validators.ValidationFailure {
+		validateStorageMappingMock = func(
+			attachments []*ovirtsdk.DiskAttachment,
+			storageMapping *[]v2vv1alpha1.ResourceMappingItem,
+			diskMapping *[]v2vv1alpha1.ResourceMappingItem,
+		) []validators.ValidationFailure {
 			return []validators.ValidationFailure{
 				validators.ValidationFailure{
 					ID:      validators.StorageMappingID,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -37,9 +37,9 @@ func ToLoggableID(id *string, name *string) string {
 	}
 	if name != nil {
 		if identifier != "" {
-			identifier = fmt.Sprintf("(%s) ", identifier)
+			identifier = fmt.Sprintf("(%s)", identifier)
 		}
-		identifier = fmt.Sprintf("%s%s ", *name, identifier)
+		identifier = fmt.Sprintf("%s%s", *name, identifier)
 	}
 	return identifier
 }


### PR DESCRIPTION
DiskMappings will allow to map source VM disk to storage class.
A mapping for a disk overrides the mapping from  StorageMappings.

DiskMappings will fail to map the disk in the following cases:
* Disk ID/Name doesn't exist for the source VM (ID precedes name)
* Target storage class doesn't exist

DiskMappings.Source.Name should hold the disk alias.

DiskMappings.Source.ID should hold the ID of the disk and not the ID of
the disk-attachment that describes its association to the VM.

DiskMappings is optional, if not provided mappings will rely on
StorageMappings.

Signed-off-by: Moti Asayag <masayag@redhat.com>