### PR TITLE
Add watching of VM and DVs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -103,6 +104,12 @@ func main() {
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup Scheme for all resources
+	if err := cdiv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
@@ -124,6 +124,9 @@ const (
 
 	// VirtualMachineReady represents the completion of the vm import
 	VirtualMachineReady SucceededConditionReason = "VirtualMachineReady"
+
+	// VirtualMachineRunning represents the completion of the vm import and vm in running state
+	VirtualMachineRunning SucceededConditionReason = "VirtualMachineRunning"
 )
 
 // ValidatingConditionReason defines the reasons for the Validating condition of VM import

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -22,6 +22,16 @@ func NewCondition(conditionType v2vv1alpha1.VirtualMachineImportConditionType, r
 	return condition
 }
 
+// NewSucceededCondition create a condition of type succeded of specific reason and message
+func NewSucceededCondition(reason string, message string) v2vv1alpha1.VirtualMachineImportCondition {
+	return NewCondition(v2vv1alpha1.Succeeded, reason, message, v1.ConditionTrue)
+}
+
+// NewProccessingCondition create a condition of type succeded of specific reason and message
+func NewProccessingCondition(reason string, message string) v2vv1alpha1.VirtualMachineImportCondition {
+	return NewCondition(v2vv1alpha1.Processing, reason, message, v1.ConditionTrue)
+}
+
 // UpsertCondition updates or creates condition in the virtualMachineImportStatus
 func UpsertCondition(vmi *v2vv1alpha1.VirtualMachineImport, condition v2vv1alpha1.VirtualMachineImportCondition) {
 	existingCondition := FindConditionOfType(vmi.Status.Conditions, condition.Type)
@@ -48,4 +58,18 @@ func FindConditionOfType(conditions []v2vv1alpha1.VirtualMachineImportCondition,
 		}
 	}
 	return nil
+}
+
+// HasSucceededConditionOfReason finds condition of a Succeeded type with conditionReason reason in the conditions slice
+func HasSucceededConditionOfReason(conditions []v2vv1alpha1.VirtualMachineImportCondition, conditionReason ...v2vv1alpha1.SucceededConditionReason) bool {
+	for _, cond := range conditions {
+		if cond.Type == v2vv1alpha1.Succeeded {
+			for _, reason := range conditionReason {
+				if *cond.Reason == string(reason) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -418,11 +418,7 @@ func (o *OvirtMapper) mapHighAvailability() *bool {
 }
 
 func (o *OvirtMapper) mapMemory() *kubevirtv1.Memory {
-	// Guest memory
-	ovirtVMMemory, _ := o.vm.Memory()
-	guestMemory, _ := resource.ParseQuantity(strconv.FormatInt(ovirtVMMemory, 10))
 	memory := &kubevirtv1.Memory{}
-	memory.Guest = &guestMemory
 
 	// HugePages
 	hp := o.mapHugePages()
@@ -456,6 +452,15 @@ func (o *OvirtMapper) mapHugePages() *kubevirtv1.Hugepages {
 
 func (o *OvirtMapper) mapResourceRequirements() kubevirtv1.ResourceRequirements {
 	reqs := kubevirtv1.ResourceRequirements{}
+
+	// Requests
+	ovirtVMMemory, _ := o.vm.Memory()
+	guestMemory, _ := resource.ParseQuantity(strconv.FormatInt(ovirtVMMemory, 10))
+	reqs.Requests = map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceMemory: guestMemory,
+	}
+
+	// Limits
 	memoryPolicy, _ := o.vm.MemoryPolicy()
 	maxMemory, _ := memoryPolicy.Max()
 	maxMemoryQuantity, _ := resource.ParseQuantity(strconv.FormatInt(maxMemory, 10))

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map Memory", func() {
 		// guest memory
-		guestMemory, _ := vmSpec.Spec.Template.Spec.Domain.Memory.Guest.AsInt64()
+		guestMemory, _ := vmSpec.Spec.Template.Spec.Domain.Resources.Requests.Memory().AsInt64()
 		Expect(guestMemory).To(Equal(vm.MustMemory()))
 
 		// huge page

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -233,33 +233,8 @@ func (o *OvirtProvider) UpdateVM(vmspec *kubevirtv1.VirtualMachine, dvs map[stri
 
 		i++
 	}
-	running := false
-	vmspec.Spec = kubevirtv1.VirtualMachineSpec{
-		Running: &running,
-		Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: labels,
-			},
-			Spec: kubevirtv1.VirtualMachineInstanceSpec{
-				Domain: kubevirtv1.DomainSpec{
-					CPU: &kubevirtv1.CPU{
-						Cores: uint32(o.vm.MustCpu().MustTopology().MustCores()),
-					},
-					Devices: kubevirtv1.Devices{
-						Disks: disks,
-						// Memory:  &kubevirtv1.Memory{},
-						// Machine:   kubevirtv1.Machine{},
-						// Firmware:  &kubevirtv1.Firmware{},
-						// Clock:     &kubevirtv1.Clock{},
-						// Features:  &kubevirtv1.Features{},
-						// Chassis:   &kubevirtv1.Chassis{},
-						// IOThreadsPolicy: &kubevirtv1.IOThreadsPolicy{},
-					},
-				},
-				Volumes: volumes,
-			},
-		},
-	}
+	vmspec.Spec.Template.Spec.Domain.Devices.Disks = disks
+	vmspec.Spec.Template.Spec.Volumes = volumes
 }
 
 // StartVM starts the source VM

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -103,3 +103,15 @@ func WithMessage(message string, newMessage string) string {
 func MakeLabelFrom(namespace string, name string) string {
 	return fmt.Sprintf("%s-%s", namespace, name)
 }
+
+// CountImportedDataVolumes return number of true values in map of booleans
+func CountImportedDataVolumes(dvsDone map[string]bool) int {
+	done := 0
+	for _, isDone := range dvsDone {
+		if isDone {
+			done++
+		}
+	}
+
+	return done
+}


### PR DESCRIPTION
This PR add:
 - vm import process monitoring as annotation
 - vm start if requested by user
 - set targetVmName of vm in status VMImport CR
 - set datavolumes of vm in status VMImport CR
 - update condtions as per flow of Vmimport process

Signed-off-by: Ondra Machacek <omachace@redhat.com>