### PR TITLE
Data Volume Secret and Config Map management refactoring

### DIFF
--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
-	provider "github.com/kubevirt/vm-import-operator/pkg/providers"
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	corev1 "k8s.io/api/core/v1"
@@ -43,16 +42,26 @@ var archMapping = map[string]string{
 	"ppc64":  "pseries",
 }
 
+// DataVolumeCredentials defines the credentials required for creating a data volume
+type DataVolumeCredentials struct {
+	URL           string
+	CACertificate string
+	KeyAccess     string
+	KeySecret     string
+	ConfigMapName string
+	SecretName    string
+}
+
 // OvirtMapper is struct that holds attributes needed to map oVirt VM to kubevirt VM
 type OvirtMapper struct {
 	vm        *ovirtsdk.Vm
 	mappings  *v2vv1alpha1.OvirtMappings
-	creds     provider.DataVolumeCredentials
+	creds     DataVolumeCredentials
 	namespace string
 }
 
 // NewOvirtMapper create ovirt mapper object
-func NewOvirtMapper(vm *ovirtsdk.Vm, mappings *v2vv1alpha1.OvirtMappings, creds provider.DataVolumeCredentials, namespace string) *OvirtMapper {
+func NewOvirtMapper(vm *ovirtsdk.Vm, mappings *v2vv1alpha1.OvirtMappings, creds DataVolumeCredentials, namespace string) *OvirtMapper {
 	return &OvirtMapper{
 		vm:        vm,
 		mappings:  mappings,

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
-	provider "github.com/kubevirt/vm-import-operator/pkg/providers"
 	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/mapper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,7 +25,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 	BeforeEach(func() {
 		vm = createVM()
 		mappings = createMappings()
-		mapper := mapper.NewOvirtMapper(vm, &mappings, provider.DataVolumeCredentials{}, "")
+		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
 		vmSpec = mapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 	})
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -23,11 +23,11 @@ type Provider interface {
 	PrepareResourceMapping(*v2vv1alpha1.ResourceMappingSpec, v2vv1alpha1.VirtualMachineImportSourceSpec)
 	Validate() ([]v2vv1alpha1.VirtualMachineImportCondition, error)
 	StopVM() error
-	GetDataVolumeCredentials() DataVolumeCredentials
 	UpdateVM(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume)
-	CreateMapper() Mapper
+	CreateMapper() (Mapper, error)
 	GetVMStatus() (VMStatus, error)
 	StartVM() error
+	CleanUp() error
 	FindTemplate() (*oapiv1.Template, error)
 	ProcessTemplate(*oapiv1.Template, string) (*kubevirtv1.VirtualMachine, error)
 }
@@ -37,16 +37,6 @@ type Mapper interface {
 	CreateEmptyVM() *kubevirtv1.VirtualMachine
 	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine
 	MapDisks() map[string]cdiv1.DataVolume
-}
-
-// DataVolumeCredentials defines the credentials required for creating a data volume
-type DataVolumeCredentials struct {
-	URL           string
-	CACertificate string
-	KeyAccess     string
-	KeySecret     string
-	ConfigMapName string
-	SecretName    string
 }
 
 // VMStatus represents VM status


### PR DESCRIPTION
Changes introduced by this PR:
- DV config map and secret management has been moved to oVirt provider, as it is oVirt-specific, which includes:
  - creation;
  - visibility restricted to the provider code;
  - clean-up (removal);
- DV config map and secret names will be generated and the objects will be  labelled with the name of "parent" Virtual Machine Import;
- DV config map and secret will be retrieved from the cluster only using label selectors.

```release-note
NONE
```