### PR TITLE
Ignore if VM already exists

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -252,7 +252,7 @@ func (r *ReconcileVirtualMachineImport) createVM(provider provider.Provider, ins
 
 	// Create kubevirt VM from source VM:
 	reqLogger.Info("Creating a new VM", "VM.Namespace", vmSpec.Namespace, "VM.Name", vmSpec.Name)
-	if err = r.client.Create(context.TODO(), vmSpec); err != nil {
+	if err = r.client.Create(context.TODO(), vmSpec); err != nil && !errors.IsAlreadyExists(err) {
 		// Update condition to failed state:
 		cond = conditions.NewSucceededCondition(string(v2vv1alpha1.VMCreationFailed), fmt.Sprintf("Error while creating virtual machine: %s", err))
 		err = r.upsertStatusCondition(instanceNamespacedName, cond)


### PR DESCRIPTION
On slow env it may happen, that when we call createVm, and right after that call we fetch it. The VM is not yet in the database. So in this case we need to ignore another call createVM, and go through of the rest of the reconcile process.

Signed-off-by: Ondra Machacek <omachace@redhat.com>