### PR TITLE
Fixing panic when source vm's id and name are missing

### DIFF
--- a/pkg/providers/ovirt/client/ovirt-client.go
+++ b/pkg/providers/ovirt/client/ovirt-client.go
@@ -195,6 +195,9 @@ func (client *richOvirtClient) fetchVM(id *string, name *string, clusterName *st
 		response *ovirtsdk.VmsServiceListResponse
 		err      error
 	)
+	if name == nil {
+		return nil, fmt.Errorf("both ID and name of the VM are missing")
+	}
 	if clusterName != nil {
 		response, err = client.connection.SystemService().VmsService().List().Search(fmt.Sprintf("name=%v and cluster=%v", *name, *clusterName)).Send()
 	} else {


### PR DESCRIPTION
When `spec.source.ovirt.vm` was missing or was present and  both `spec.source.ovirt.vm.id` and `spec.source.ovirt.name` were missing, there was a panic originating from https://github.com/kubevirt/vm-import-operator/blob/7fc785983d5dfcbd9715acf4e6a5477672746d12/pkg/providers/ovirt/client/ovirt-client.go#L201
```release-note
NONE
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>