### PR TITLE
Ignore missing storage resource mapping

### DIFF
--- a/pkg/providers/ovirt/validation/validators/definitions.go
+++ b/pkg/providers/ovirt/validation/validators/definitions.go
@@ -115,12 +115,8 @@ const (
 	NetworkTypeID = CheckID("network.type")
 	// NetworkTargetID defines an ID of a check verifyting existence of target network
 	NetworkTargetID = CheckID("network.target")
-	// StorageMappingID defines an ID of a check verifying that all the required source storage domains are present in the resource mapping
-	StorageMappingID = CheckID("storage.mapping")
 	// StorageTargetID defines an ID of a check verifying existence of target storage class
 	StorageTargetID = CheckID("storage.target")
-	// DiskMappingID defines an ID of a check verifying that all the required source disks are present in the resource mapping
-	DiskMappingID = CheckID("disk.mapping")
 	// DiskTargetID defines an ID of a check verifying existence of target storage class
 	DiskTargetID = CheckID("disk.target")
 )

--- a/pkg/providers/ovirt/validation/vm-import-validation_test.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation_test.go
@@ -10,9 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -373,8 +370,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 			diskMapping *[]v2vv1alpha1.ResourceMappingItem,
 		) []validators.ValidationFailure {
 			return []validators.ValidationFailure{
-				validators.ValidationFailure{
-					ID:      validators.StorageMappingID,
+				{
+					ID:      validators.StorageTargetID,
 					Message: message,
 				},
 			}
@@ -421,11 +418,4 @@ func newNamespacedName() *types.NamespacedName {
 		Namespace: "bar",
 	}
 	return &nn
-}
-
-func decoderFor(gv schema.GroupVersion) runtime.Decoder {
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(gv)
-	codecs := serializer.NewCodecFactory(scheme)
-	return codecs.UniversalDecoder()
 }


### PR DESCRIPTION
Ignoring missing storage resource mapping to allow for assigning default storage class later.
Fixes #65
```release-note
NONE
```

Signed-off-by: Jakub Dzon <jdzon@redhat.com>