### PR TITLE
Stopping oVirt VM if cached VM status is not 'down'

### DIFF
--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -171,6 +171,10 @@ func (o *OvirtProvider) Validate() ([]v2vv1alpha1.VirtualMachineImportCondition,
 // StopVM stop the source VM on ovirt
 func (o *OvirtProvider) StopVM() error {
 	vmID, _ := o.vm.Id()
+	status, _ := o.vm.Status()
+	if status == ovirtsdk.VMSTATUS_DOWN {
+		return nil
+	}
 	err := o.ovirtClient.StopVM(vmID)
 	if err != nil {
 		return err


### PR DESCRIPTION
 - oVirt client will aways send shutdown command;
 - oVirt provider will request VM shutdown only if locally cached VM status is not 'down';

Fixes #78

```release-note
NONE
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>