### PR TITLE
Use suffixes in memory and disk size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kubevirt/vm-import-operator
 go 1.13
 
 require (
+	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 	github.com/go-openapi/spec v0.19.4
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20191119172530-79f836b90111
 	github.com/onsi/ginkgo v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/ant31/crd-validation v0.0.0-20180702145049-30f8a35d0ac2/go.mod h1:X0noFIik9YqfhGYBLEHg8LJKEwy7QIitLQuFMpKLcPk=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -190,7 +190,10 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 	}
 
 	// Import disks:
-	dvs := mapper.MapDisks()
+	dvs, err := mapper.MapDisks()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	dvsDone := make(map[string]bool)
 	for dvID := range dvs {
 		foundDv := &cdiv1.DataVolume{}
@@ -246,7 +249,10 @@ func (r *ReconcileVirtualMachineImport) createVM(provider provider.Provider, ins
 			spec = mapper.CreateEmptyVM()
 		}
 	}
-	vmSpec := mapper.MapVM(instance.Spec.TargetVMName, spec)
+	vmSpec, err := mapper.MapVM(instance.Spec.TargetVMName, spec)
+	if err != nil {
+		return "", err
+	}
 
 	// Update progress:
 	if err = r.updateProgress(instance, progressStart); err != nil {

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -2,7 +2,6 @@ package mapper
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
@@ -87,7 +86,8 @@ func (o *OvirtMapper) CreateEmptyVM() *kubevirtv1.VirtualMachine {
 }
 
 // MapVM map oVirt API VM definition to kubevirt VM definition
-func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
+func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	var err error
 	// Set Namespace
 	vmSpec.ObjectMeta.Namespace = o.namespace
 
@@ -124,7 +124,9 @@ func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMach
 	vmSpec.Spec.Template.Spec.Domain.Memory = o.mapMemory()
 
 	// Memory policy set the memory limit
-	vmSpec.Spec.Template.Spec.Domain.Resources = o.mapResourceRequirements()
+	if vmSpec.Spec.Template.Spec.Domain.Resources, err = o.mapResourceRequirements(); err != nil {
+		return vmSpec, err
+	}
 
 	// Devices
 	vmSpec.Spec.Template.Spec.Domain.Devices = *o.mapGraphicalConsoles()
@@ -148,12 +150,12 @@ func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMach
 	networkToType := o.mapNetworksToTypes(vmSpec.Spec.Template.Spec.Networks)
 	vmSpec.Spec.Template.Spec.Domain.Devices.Interfaces = o.mapNics(networkToType)
 
-	return vmSpec
+	return vmSpec, nil
 }
 
 // MapDisks map the oVirt VM disks to the map of CDI DataVolumes specification, where
 // map id is the id of the oVirt disk
-func (o *OvirtMapper) MapDisks() map[string]cdiv1.DataVolume {
+func (o *OvirtMapper) MapDisks() (map[string]cdiv1.DataVolume, error) {
 	// TODO: stateless, boot_devices, floppy/cdrom
 	diskAttachments, _ := o.vm.DiskAttachments()
 	dvs := make(map[string]cdiv1.DataVolume, len(diskAttachments.Slice()))
@@ -164,7 +166,11 @@ func (o *OvirtMapper) MapDisks() map[string]cdiv1.DataVolume {
 		diskID, _ := disk.Id()
 		sdClass := o.getStorageClassForDisk(disk, o.mappings)
 		diskSize, _ := disk.ProvisionedSize()
-		quantity, _ := resource.ParseQuantity(strconv.FormatInt(diskSize, 10))
+		diskSizeConverted, err := utils.FormatBytes(diskSize)
+		if err != nil {
+			return dvs, err
+		}
+		quantity, _ := resource.ParseQuantity(diskSizeConverted)
 
 		dvs[attachID] = cdiv1.DataVolume{
 			TypeMeta: metav1.TypeMeta{
@@ -200,7 +206,7 @@ func (o *OvirtMapper) MapDisks() map[string]cdiv1.DataVolume {
 			dvs[attachID].Spec.PVC.StorageClassName = sdClass
 		}
 	}
-	return dvs
+	return dvs, nil
 }
 
 func (o *OvirtMapper) mapNics(networkToType map[string]string) []kubevirtv1.Interface {
@@ -468,12 +474,16 @@ func (o *OvirtMapper) mapHugePages() *kubevirtv1.Hugepages {
 	return nil
 }
 
-func (o *OvirtMapper) mapResourceRequirements() kubevirtv1.ResourceRequirements {
+func (o *OvirtMapper) mapResourceRequirements() (kubevirtv1.ResourceRequirements, error) {
 	reqs := kubevirtv1.ResourceRequirements{}
 
 	// Requests
 	ovirtVMMemory, _ := o.vm.Memory()
-	guestMemory, _ := resource.ParseQuantity(strconv.FormatInt(ovirtVMMemory, 10))
+	vmMemoryConverted, err := utils.FormatBytes(ovirtVMMemory)
+	if err != nil {
+		return reqs, err
+	}
+	guestMemory, _ := resource.ParseQuantity(vmMemoryConverted)
 	reqs.Requests = map[corev1.ResourceName]resource.Quantity{
 		corev1.ResourceMemory: guestMemory,
 	}
@@ -481,12 +491,16 @@ func (o *OvirtMapper) mapResourceRequirements() kubevirtv1.ResourceRequirements 
 	// Limits
 	memoryPolicy, _ := o.vm.MemoryPolicy()
 	maxMemory, _ := memoryPolicy.Max()
-	maxMemoryQuantity, _ := resource.ParseQuantity(strconv.FormatInt(maxMemory, 10))
+	maxMemoryConverted, err := utils.FormatBytes(maxMemory)
+	if err != nil {
+		return reqs, err
+	}
+	maxMemoryQuantity, _ := resource.ParseQuantity(maxMemoryConverted)
 	reqs.Limits = map[corev1.ResourceName]resource.Quantity{
 		corev1.ResourceMemory: maxMemoryQuantity,
 	}
 
-	return reqs
+	return reqs, nil
 }
 
 // Graphical console is attached only in case the VM is not in headless mode

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		vm = createVM()
 		mappings = createMappings()
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
-		vmSpec = mapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
+		vmSpec, _ = mapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 	})
 
 	It("should map name", func() {
@@ -141,7 +141,7 @@ var _ = Describe("Test mapping disks", func() {
 		namespace := "the-namespace"
 		mapper := mapper.NewOvirtMapper(vm, &mappings, credentials, namespace)
 		daName := "123"
-		dvs := mapper.MapDisks()
+		dvs, _ := mapper.MapDisks()
 
 		Expect(dvs).To(HaveLen(1))
 		Expect(dvs).To(HaveKey(daName))
@@ -161,7 +161,7 @@ var _ = Describe("Test mapping disks", func() {
 		Expect(dv.Spec.PVC.AccessModes).To(HaveLen(1))
 		Expect(dv.Spec.PVC.Resources.Requests).To(HaveKey(corev1.ResourceStorage))
 		storageResource := dv.Spec.PVC.Resources.Requests[corev1.ResourceStorage]
-		Expect(storageResource.Format).To(Equal(resource.DecimalSI))
+		Expect(storageResource.Format).To(Equal(resource.BinarySI))
 		Expect(storageResource.Value()).To(BeEquivalentTo(memoryGI))
 
 		Expect(dv.Spec.PVC.StorageClassName).To(Not(BeNil()))
@@ -187,7 +187,7 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
 
-		dvs := mapper.MapDisks()
+		dvs, _ := mapper.MapDisks()
 
 		Expect(dvs).To(HaveLen(1))
 		Expect(dvs["123"].Spec.PVC.StorageClassName).To(Not(BeNil()))

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -35,8 +35,8 @@ type Provider interface {
 // Mapper is interface to be used for mapping external VM to kubevirt VM
 type Mapper interface {
 	CreateEmptyVM() *kubevirtv1.VirtualMachine
-	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine
-	MapDisks() map[string]cdiv1.DataVolume
+	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
+	MapDisks() (map[string]cdiv1.DataVolume, error)
 }
 
 // VMStatus represents VM status

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/alecthomas/units"
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 )
@@ -114,4 +115,28 @@ func CountImportedDataVolumes(dvsDone map[string]bool) int {
 	}
 
 	return done
+}
+
+// FormatBytes convert bytes to highest suffix
+func FormatBytes(bytes int64) (string, error) {
+	if bytes < 0 {
+		return "", fmt.Errorf("bytes can't be negative")
+	}
+
+	kib := int64(units.KiB)
+	if bytes < kib {
+		return fmt.Sprintf("%d", bytes), nil
+	}
+	suffix := 0
+	n := int64(kib)
+	for i := bytes / kib; i >= kib; i /= kib {
+		n *= kib
+		suffix++
+	}
+	// Return bytes in case we can't express exact number in highest suffix
+	if bytes % n > 0 {
+		return fmt.Sprintf("%d", bytes), nil
+	}
+
+	return fmt.Sprintf("%d%ci", bytes/n, "KMGTPE"[suffix]), nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"strings"
 
+	"github.com/alecthomas/units"
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -45,6 +46,25 @@ var _ = Describe("Validating Name Normalization", func() {
 		table.Entry("Max length", createStringOfLength(k8svalidation.DNS1123SubdomainMaxLength)),
 		table.Entry("Max length exceeded by 1", createStringOfLength(k8svalidation.DNS1123SubdomainMaxLength+1)),
 		table.Entry("Double the max length", createStringOfLength(k8svalidation.DNS1123SubdomainMaxLength*2)),
+	)
+})
+
+var _ = Describe("Converting of bytes", func() {
+	table.DescribeTable("should convert to proper suffix", func(bytes int64, expected string) {
+		result, _ := utils.FormatBytes(bytes)
+		Expect(result).To(Equal(expected))
+	},
+		table.Entry("To Ki", int64(units.KiB), "1Ki"),
+		table.Entry("To Ki", int64(12*units.KiB), "12Ki"),
+		table.Entry("To Mi", int64(units.MiB), "1Mi"),
+		table.Entry("To Mi", int64(512*units.MiB), "512Mi"),
+		table.Entry("To Gi", int64(units.GiB), "1Gi"),
+		table.Entry("To Gi", int64(4*units.GiB), "4Gi"),
+		table.Entry("To Ti", int64(units.TiB), "1Ti"),
+		table.Entry("To Pi", int64(units.PiB), "1Pi"),
+		table.Entry("To Ei", int64(units.EiB), "1Ei"),
+		table.Entry("To B", int64(1), "1"),
+		table.Entry("No conversion", int64(units.GiB-1), "1073741823"),
 	)
 })
 

--- a/vendor/github.com/alecthomas/units/COPYING
+++ b/vendor/github.com/alecthomas/units/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Alec Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/alecthomas/units/README.md
+++ b/vendor/github.com/alecthomas/units/README.md
@@ -1,0 +1,11 @@
+# Units - Helpful unit multipliers and functions for Go
+
+The goal of this package is to have functionality similar to the [time](http://golang.org/pkg/time/) package.
+
+It allows for code like this:
+
+```go
+n, err := ParseBase2Bytes("1KB")
+// n == 1024
+n = units.Mebibyte * 512
+```

--- a/vendor/github.com/alecthomas/units/bytes.go
+++ b/vendor/github.com/alecthomas/units/bytes.go
@@ -1,0 +1,83 @@
+package units
+
+// Base2Bytes is the old non-SI power-of-2 byte scale (1024 bytes in a kilobyte,
+// etc.).
+type Base2Bytes int64
+
+// Base-2 byte units.
+const (
+	Kibibyte Base2Bytes = 1024
+	KiB                 = Kibibyte
+	Mebibyte            = Kibibyte * 1024
+	MiB                 = Mebibyte
+	Gibibyte            = Mebibyte * 1024
+	GiB                 = Gibibyte
+	Tebibyte            = Gibibyte * 1024
+	TiB                 = Tebibyte
+	Pebibyte            = Tebibyte * 1024
+	PiB                 = Pebibyte
+	Exbibyte            = Pebibyte * 1024
+	EiB                 = Exbibyte
+)
+
+var (
+	bytesUnitMap    = MakeUnitMap("iB", "B", 1024)
+	oldBytesUnitMap = MakeUnitMap("B", "B", 1024)
+)
+
+// ParseBase2Bytes supports both iB and B in base-2 multipliers. That is, KB
+// and KiB are both 1024.
+func ParseBase2Bytes(s string) (Base2Bytes, error) {
+	n, err := ParseUnit(s, bytesUnitMap)
+	if err != nil {
+		n, err = ParseUnit(s, oldBytesUnitMap)
+	}
+	return Base2Bytes(n), err
+}
+
+func (b Base2Bytes) String() string {
+	return ToString(int64(b), 1024, "iB", "B")
+}
+
+var (
+	metricBytesUnitMap = MakeUnitMap("B", "B", 1000)
+)
+
+// MetricBytes are SI byte units (1000 bytes in a kilobyte).
+type MetricBytes SI
+
+// SI base-10 byte units.
+const (
+	Kilobyte MetricBytes = 1000
+	KB                   = Kilobyte
+	Megabyte             = Kilobyte * 1000
+	MB                   = Megabyte
+	Gigabyte             = Megabyte * 1000
+	GB                   = Gigabyte
+	Terabyte             = Gigabyte * 1000
+	TB                   = Terabyte
+	Petabyte             = Terabyte * 1000
+	PB                   = Petabyte
+	Exabyte              = Petabyte * 1000
+	EB                   = Exabyte
+)
+
+// ParseMetricBytes parses base-10 metric byte units. That is, KB is 1000 bytes.
+func ParseMetricBytes(s string) (MetricBytes, error) {
+	n, err := ParseUnit(s, metricBytesUnitMap)
+	return MetricBytes(n), err
+}
+
+func (m MetricBytes) String() string {
+	return ToString(int64(m), 1000, "B", "B")
+}
+
+// ParseStrictBytes supports both iB and B suffixes for base 2 and metric,
+// respectively. That is, KiB represents 1024 and KB represents 1000.
+func ParseStrictBytes(s string) (int64, error) {
+	n, err := ParseUnit(s, bytesUnitMap)
+	if err != nil {
+		n, err = ParseUnit(s, metricBytesUnitMap)
+	}
+	return int64(n), err
+}

--- a/vendor/github.com/alecthomas/units/doc.go
+++ b/vendor/github.com/alecthomas/units/doc.go
@@ -1,0 +1,13 @@
+// Package units provides helpful unit multipliers and functions for Go.
+//
+// The goal of this package is to have functionality similar to the time [1] package.
+//
+//
+// [1] http://golang.org/pkg/time/
+//
+// It allows for code like this:
+//
+//     n, err := ParseBase2Bytes("1KB")
+//     // n == 1024
+//     n = units.Mebibyte * 512
+package units

--- a/vendor/github.com/alecthomas/units/go.mod
+++ b/vendor/github.com/alecthomas/units/go.mod
@@ -1,0 +1,1 @@
+module github.com/alecthomas/units

--- a/vendor/github.com/alecthomas/units/si.go
+++ b/vendor/github.com/alecthomas/units/si.go
@@ -1,0 +1,26 @@
+package units
+
+// SI units.
+type SI int64
+
+// SI unit multiples.
+const (
+	Kilo SI = 1000
+	Mega    = Kilo * 1000
+	Giga    = Mega * 1000
+	Tera    = Giga * 1000
+	Peta    = Tera * 1000
+	Exa     = Peta * 1000
+)
+
+func MakeUnitMap(suffix, shortSuffix string, scale int64) map[string]float64 {
+	return map[string]float64{
+		shortSuffix:  1,
+		"K" + suffix: float64(scale),
+		"M" + suffix: float64(scale * scale),
+		"G" + suffix: float64(scale * scale * scale),
+		"T" + suffix: float64(scale * scale * scale * scale),
+		"P" + suffix: float64(scale * scale * scale * scale * scale),
+		"E" + suffix: float64(scale * scale * scale * scale * scale * scale),
+	}
+}

--- a/vendor/github.com/alecthomas/units/util.go
+++ b/vendor/github.com/alecthomas/units/util.go
@@ -1,0 +1,138 @@
+package units
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	siUnits = []string{"", "K", "M", "G", "T", "P", "E"}
+)
+
+func ToString(n int64, scale int64, suffix, baseSuffix string) string {
+	mn := len(siUnits)
+	out := make([]string, mn)
+	for i, m := range siUnits {
+		if n%scale != 0 || i == 0 && n == 0 {
+			s := suffix
+			if i == 0 {
+				s = baseSuffix
+			}
+			out[mn-1-i] = fmt.Sprintf("%d%s%s", n%scale, m, s)
+		}
+		n /= scale
+		if n == 0 {
+			break
+		}
+	}
+	return strings.Join(out, "")
+}
+
+// Below code ripped straight from http://golang.org/src/pkg/time/format.go?s=33392:33438#L1123
+var errLeadingInt = errors.New("units: bad [0-9]*") // never printed
+
+// leadingInt consumes the leading [0-9]* from s.
+func leadingInt(s string) (x int64, rem string, err error) {
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if x >= (1<<63-10)/10 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+		x = x*10 + int64(c) - '0'
+	}
+	return x, s[i:], nil
+}
+
+func ParseUnit(s string, unitMap map[string]float64) (int64, error) {
+	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
+	orig := s
+	f := float64(0)
+	neg := false
+
+	// Consume [-+]?
+	if s != "" {
+		c := s[0]
+		if c == '-' || c == '+' {
+			neg = c == '-'
+			s = s[1:]
+		}
+	}
+	// Special case: if all that is left is "0", this is zero.
+	if s == "0" {
+		return 0, nil
+	}
+	if s == "" {
+		return 0, errors.New("units: invalid " + orig)
+	}
+	for s != "" {
+		g := float64(0) // this element of the sequence
+
+		var x int64
+		var err error
+
+		// The next character must be [0-9.]
+		if !(s[0] == '.' || ('0' <= s[0] && s[0] <= '9')) {
+			return 0, errors.New("units: invalid " + orig)
+		}
+		// Consume [0-9]*
+		pl := len(s)
+		x, s, err = leadingInt(s)
+		if err != nil {
+			return 0, errors.New("units: invalid " + orig)
+		}
+		g = float64(x)
+		pre := pl != len(s) // whether we consumed anything before a period
+
+		// Consume (\.[0-9]*)?
+		post := false
+		if s != "" && s[0] == '.' {
+			s = s[1:]
+			pl := len(s)
+			x, s, err = leadingInt(s)
+			if err != nil {
+				return 0, errors.New("units: invalid " + orig)
+			}
+			scale := 1.0
+			for n := pl - len(s); n > 0; n-- {
+				scale *= 10
+			}
+			g += float64(x) / scale
+			post = pl != len(s)
+		}
+		if !pre && !post {
+			// no digits (e.g. ".s" or "-.s")
+			return 0, errors.New("units: invalid " + orig)
+		}
+
+		// Consume unit.
+		i := 0
+		for ; i < len(s); i++ {
+			c := s[i]
+			if c == '.' || ('0' <= c && c <= '9') {
+				break
+			}
+		}
+		u := s[:i]
+		s = s[i:]
+		unit, ok := unitMap[u]
+		if !ok {
+			return 0, errors.New("units: unknown unit " + u + " in " + orig)
+		}
+
+		f += g * unit
+	}
+
+	if neg {
+		f = -f
+	}
+	if f < float64(-1<<63) || f > float64(1<<63-1) {
+		return 0, errors.New("units: overflow parsing unit")
+	}
+	return int64(f), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,6 +17,8 @@ github.com/BurntSushi/toml
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+github.com/alecthomas/units
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.0


### PR DESCRIPTION
This PR add a suffix to memory and disk attributes, so it is better
readable for the user instead of using bytes.

Signed-off-by: Ondra Machacek <omachace@redhat.com>