### PR TITLE
Rename status conditions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -746,6 +747,7 @@ gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -927,6 +929,7 @@ gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmK
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.6.1-0.20190607001116-5213b8090861 h1:ppLucX0K/60T3t6LPZQzTOkt5PytkEbQLIaSteq+TpE=
 google.golang.org/api v0.6.1-0.20190607001116-5213b8090861/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -943,6 +946,7 @@ google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 h1:UXl+Zk3jqqcbEVV7ace5lrt4YdA4tXiz3f/KbmD29Vo=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -951,6 +955,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
@@ -97,8 +97,8 @@ const (
 	// Valid represents the status of the validation of the mapping rules and eligibility of source VM for import
 	Valid VirtualMachineImportConditionType = "Valid"
 
-	// MappingRulesChecking represents the status of the VM import mapping rules checking
-	MappingRulesChecking VirtualMachineImportConditionType = "MappingRulesChecking"
+	// MappingRulesVerified represents the status of the VM import mapping rules checking
+	MappingRulesVerified VirtualMachineImportConditionType = "MappingRulesVerified"
 
 	// Processing represents the status of the VM import process while in progress
 	Processing VirtualMachineImportConditionType = "Processing"
@@ -154,20 +154,20 @@ const (
 	IncompleteMappingRules ValidConditionReason = "IncompleteMappingRules"
 )
 
-// MappingRulesCheckingReason defines the reasons for the MappingRulesChecking condition of VM import
+// MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import
 // +k8s:openapi-gen=true
-type MappingRulesCheckingReason string
+type MappingRulesVerifiedReason string
 
-// These are valid reasons for the Valid conditions of VM import.
+// These are valid reasons for the MappingRulesVerified conditions of VM import.
 const (
-	// Completed represents the completion of the mapping rules checking without warnings or errors
-	MappingRulesCheckingCompleted MappingRulesCheckingReason = "MappingRulesCheckingCompleted"
+	// MappingRulesVerificationCompleted represents the completion of the mapping rules checking without warnings or errors
+	MappingRulesVerificationCompleted MappingRulesVerifiedReason = "MappingRulesVerificationCompleted"
 
-	// MappingRulesViolated represents the violation of the mapping rules
-	MappingRulesCheckingFailed MappingRulesCheckingReason = "MappingRulesCheckingFailed"
+	// MappingRulesVerificationFailed represents the violation of the mapping rules
+	MappingRulesVerificationFailed MappingRulesVerifiedReason = "MappingRulesVerificationFailed"
 
-	// MappingRulesWarningsReported represents the existence of warnings as a result of checking the mapping rules
-	MappingRulesCheckingReportedWarnings MappingRulesCheckingReason = "MappingRulesCheckingReportedWarnings"
+	// MappingRulesVerificationReportedWarnings represents the existence of warnings as a result of checking the mapping rules
+	MappingRulesVerificationReportedWarnings MappingRulesVerifiedReason = "MappingRulesVerificationReportedWarnings"
 )
 
 // ProcessingConditionReason defines the reasons for the Processing condition of VM import

--- a/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
@@ -94,8 +94,8 @@ const (
 	// Succeeded represents status of the VM import process being completed successfully
 	Succeeded VirtualMachineImportConditionType = "Succeeded"
 
-	// Validating represents the status of the validation of the mapping rules and eligibility of source VM for import
-	Validating VirtualMachineImportConditionType = "Validating"
+	// Valid represents the status of the validation of the mapping rules and eligibility of source VM for import
+	Valid VirtualMachineImportConditionType = "Valid"
 
 	// MappingRulesChecking represents the status of the VM import mapping rules checking
 	MappingRulesChecking VirtualMachineImportConditionType = "MappingRulesChecking"
@@ -129,36 +129,36 @@ const (
 	VirtualMachineRunning SucceededConditionReason = "VirtualMachineRunning"
 )
 
-// ValidatingConditionReason defines the reasons for the Validating condition of VM import
+// ValidConditionReason defines the reasons for the Valid condition of VM import
 // +k8s:openapi-gen=true
-type ValidatingConditionReason string
+type ValidConditionReason string
 
-// These are valid reasons for the Validating conditions of VM import.
+// These are valid reasons for the Valid conditions of VM import.
 const (
 	// ValidationCompleted represents the completion of the vm import resource validating
-	ValidationCompleted ValidatingConditionReason = "ValidationCompleted"
+	ValidationCompleted ValidConditionReason = "ValidationCompleted"
 
 	// SecretNotFound represents the nonexistence of the provider's secret
-	SecretNotFound ValidatingConditionReason = "SecretNotFound"
+	SecretNotFound ValidConditionReason = "SecretNotFound"
 
 	// MappingResourceNotFound represents the nonexistence of the mapping resource
-	MappingResourceNotFound ValidatingConditionReason = "MappingResourceNotFound"
+	MappingResourceNotFound ValidConditionReason = "MappingResourceNotFound"
 
 	// UnreachableProvider represents a failure to connect to the provider
-	UnreachableProvider ValidatingConditionReason = "UnreachableProvider"
+	UnreachableProvider ValidConditionReason = "UnreachableProvider"
 
 	// SourceVmNotFound represents the nonexistence of the source VM
-	SourceVMNotFound ValidatingConditionReason = "SourceVMNotFound"
+	SourceVMNotFound ValidConditionReason = "SourceVMNotFound"
 
 	// IncompleteMappingRules represents the inability to prepare the mapping rules
-	IncompleteMappingRules ValidatingConditionReason = "IncompleteMappingRules"
+	IncompleteMappingRules ValidConditionReason = "IncompleteMappingRules"
 )
 
 // MappingRulesCheckingReason defines the reasons for the MappingRulesChecking condition of VM import
 // +k8s:openapi-gen=true
 type MappingRulesCheckingReason string
 
-// These are valid reasons for the Validating conditions of VM import.
+// These are valid reasons for the Valid conditions of VM import.
 const (
 	// Completed represents the completion of the mapping rules checking without warnings or errors
 	MappingRulesCheckingCompleted MappingRulesCheckingReason = "MappingRulesCheckingCompleted"

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -28,8 +28,8 @@ func NewSucceededCondition(reason string, message string, status v1.ConditionSta
 }
 
 // NewProcessingCondition create a condition of type Processing of specific reason and message
-func NewProcessingCondition(reason string, message string) v2vv1alpha1.VirtualMachineImportCondition {
-	return NewCondition(v2vv1alpha1.Processing, reason, message, v1.ConditionTrue)
+func NewProcessingCondition(reason string, message string, status v1.ConditionStatus) v2vv1alpha1.VirtualMachineImportCondition {
+	return NewCondition(v2vv1alpha1.Processing, reason, message, status)
 }
 
 // UpsertCondition updates or creates condition in the virtualMachineImportStatus

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Condition management", func() {
 	It("should find condition by type", func() {
 		validating := v2vv1alpha1.VirtualMachineImportCondition{
-			Type: v2vv1alpha1.Validating,
+			Type: v2vv1alpha1.Valid,
 		}
 		processing := v2vv1alpha1.VirtualMachineImportCondition{
 			Type: v2vv1alpha1.Processing,
@@ -32,7 +32,7 @@ var _ = Describe("Condition management", func() {
 	})
 	It("should not find condition by type when it doesn't exist", func() {
 		validating := v2vv1alpha1.VirtualMachineImportCondition{
-			Type: v2vv1alpha1.Validating,
+			Type: v2vv1alpha1.Valid,
 		}
 		processing := v2vv1alpha1.VirtualMachineImportCondition{
 			Type: v2vv1alpha1.Processing,
@@ -48,7 +48,7 @@ var _ = Describe("Condition management", func() {
 	})
 	It("should add condition", func() {
 		validating := v2vv1alpha1.VirtualMachineImportCondition{
-			Type: v2vv1alpha1.Validating,
+			Type: v2vv1alpha1.Valid,
 		}
 		vmi := v2vv1alpha1.VirtualMachineImport{
 			Status: v2vv1alpha1.VirtualMachineImportStatus{
@@ -75,7 +75,7 @@ var _ = Describe("Condition management", func() {
 
 		updatedConditions := vmi.Status.Conditions
 		Expect(updatedConditions).To(HaveLen(2))
-		foundValidating := conditions.FindConditionOfType(updatedConditions, v2vv1alpha1.Validating)
+		foundValidating := conditions.FindConditionOfType(updatedConditions, v2vv1alpha1.Valid)
 		Expect(*foundValidating).To(Equal(validating))
 
 		foundProcessing := conditions.FindConditionOfType(updatedConditions, v2vv1alpha1.Processing)
@@ -91,7 +91,7 @@ var _ = Describe("Condition management", func() {
 		oldReason := "old-reason"
 		minuteAgo := metav1.NewTime(time.Now().Add(-time.Minute))
 		beforeUpdate := v2vv1alpha1.VirtualMachineImportCondition{
-			Type:               v2vv1alpha1.Validating,
+			Type:               v2vv1alpha1.Valid,
 			Message:            &oldMessage,
 			Reason:             &oldReason,
 			Status:             v1.ConditionFalse,
@@ -111,7 +111,7 @@ var _ = Describe("Condition management", func() {
 		status := v1.ConditionTrue
 		now := metav1.NewTime(time.Now())
 		newCondition := v2vv1alpha1.VirtualMachineImportCondition{
-			Type:               v2vv1alpha1.Validating,
+			Type:               v2vv1alpha1.Valid,
 			Message:            &message,
 			Reason:             &reason,
 			Status:             status,
@@ -123,7 +123,7 @@ var _ = Describe("Condition management", func() {
 
 		updatedConditions := vmi.Status.Conditions
 		Expect(updatedConditions).To(HaveLen(1))
-		found := conditions.FindConditionOfType(updatedConditions, v2vv1alpha1.Validating)
+		found := conditions.FindConditionOfType(updatedConditions, v2vv1alpha1.Valid)
 		Expect(*found.Message).To(Equal(message))
 		Expect(*found.Reason).To(Equal(reason))
 		Expect(found.Status).To(Equal(status))

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Condition management", func() {
 			processing,
 		}
 
-		found := conditions.FindConditionOfType(vmiConditions, v2vv1alpha1.MappingRulesChecking)
+		found := conditions.FindConditionOfType(vmiConditions, v2vv1alpha1.MappingRulesVerified)
 
 		Expect(found).To(BeNil())
 	})

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -467,10 +467,10 @@ func (r *ReconcileVirtualMachineImport) fetchResourceMapping(resourceMappingID *
 }
 
 func shouldValidate(vmiStatus *v2vv1alpha1.VirtualMachineImportStatus) bool {
-	validatingCondition := conditions.FindConditionOfType(vmiStatus.Conditions, v2vv1alpha1.Validating)
+	validCondition := conditions.FindConditionOfType(vmiStatus.Conditions, v2vv1alpha1.Valid)
 	rulesCheckingCondition := conditions.FindConditionOfType(vmiStatus.Conditions, v2vv1alpha1.MappingRulesChecking)
 
-	return isIncomplete(validatingCondition) || isIncomplete(rulesCheckingCondition)
+	return isIncomplete(validCondition) || isIncomplete(rulesCheckingCondition)
 }
 
 func isIncomplete(condition *v2vv1alpha1.VirtualMachineImportCondition) bool {
@@ -703,7 +703,7 @@ func (r *ReconcileVirtualMachineImport) initProvider(instance *v2vv1alpha1.Virtu
 	// Load the external resource mapping
 	resourceMapping, err := r.fetchResourceMapping(instance.Spec.ResourceMapping, instance.Namespace)
 	if err != nil {
-		//TODO: update Validating status condition
+		//TODO: update Valid status condition
 		return err
 	}
 

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -269,8 +269,8 @@ func (r *ReconcileVirtualMachineImport) createVM(provider provider.Provider, ins
 	}
 
 	// Update condition to creating VM:
-	cond := conditions.NewProcessingCondition(string(v2vv1alpha1.CreatingTargetVM), "Creating virtual machine")
-	if err = r.upsertStatusCondition(instanceNamespacedName, cond); err != nil {
+	processingCond := conditions.NewProcessingCondition(string(v2vv1alpha1.CreatingTargetVM), "Creating virtual machine", corev1.ConditionTrue)
+	if err = r.upsertStatusConditions(instanceNamespacedName, processingCond); err != nil {
 		return "", err
 	}
 
@@ -278,8 +278,11 @@ func (r *ReconcileVirtualMachineImport) createVM(provider provider.Provider, ins
 	reqLogger.Info("Creating a new VM", "VM.Namespace", vmSpec.Namespace, "VM.Name", vmSpec.Name)
 	if err = r.client.Create(context.TODO(), vmSpec); err != nil {
 		// Update condition to failed state:
-		cond = conditions.NewSucceededCondition(string(v2vv1alpha1.VMCreationFailed), fmt.Sprintf("Error while creating virtual machine: %s", err), corev1.ConditionFalse)
-		err = r.upsertStatusCondition(instanceNamespacedName, cond)
+		succeededCond := conditions.NewSucceededCondition(string(v2vv1alpha1.VMCreationFailed), fmt.Sprintf("Error while creating virtual machine: %s", err), corev1.ConditionFalse)
+		processingCond.Status = corev1.ConditionFalse
+		if err = r.upsertStatusConditions(instanceNamespacedName, succeededCond, processingCond); err != nil {
+			return "", err
+		}
 
 		// Cleanup after failure
 		if err = r.afterFailure(instanceNamespacedName, provider); err != nil {
@@ -324,15 +327,13 @@ func (r *ReconcileVirtualMachineImport) startVM(provider provider.Provider, inst
 			}
 		} else if err == nil {
 			if vmi.Status.Phase == kubevirtv1.Running || vmi.Status.Phase == kubevirtv1.Scheduled {
-				instanceNamespacedName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
-				cond := conditions.NewSucceededCondition(string(v2vv1alpha1.VirtualMachineRunning), "Virtual machine running", corev1.ConditionTrue)
-				err = r.upsertStatusCondition(instanceNamespacedName, cond)
-				if err != nil {
+				if err = r.updateConditionsAfterSuccess(instance, "Virtual machine running", v2vv1alpha1.VirtualMachineRunning); err != nil {
 					return err
 				}
 				if err = r.updateProgress(instance, progressDone); err != nil {
 					return err
 				}
+				instanceNamespacedName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 				if err = r.afterSuccess(vmName, instanceNamespacedName, provider); err != nil {
 					return err
 				}
@@ -343,6 +344,20 @@ func (r *ReconcileVirtualMachineImport) startVM(provider provider.Provider, inst
 	}
 
 	return nil
+}
+
+func (r *ReconcileVirtualMachineImport) updateConditionsAfterSuccess(instance *v2vv1alpha1.VirtualMachineImport, message string, reason v2vv1alpha1.SucceededConditionReason) error {
+	succeededCond := conditions.NewSucceededCondition(string(reason), message, corev1.ConditionTrue)
+	conds := []v2vv1alpha1.VirtualMachineImportCondition{succeededCond}
+
+	processingCond := conditions.FindConditionOfType(instance.Status.Conditions, v2vv1alpha1.Processing)
+	if processingCond != nil {
+		processingCond.Status = corev1.ConditionFalse
+		conds = append(conds, *processingCond)
+	}
+
+	instanceNamespacedName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
+	return r.upsertStatusConditions(instanceNamespacedName, conds...)
 }
 
 func shouldStartVM(instance *v2vv1alpha1.VirtualMachineImport) bool {
@@ -357,9 +372,7 @@ func (r *ReconcileVirtualMachineImport) manageDataVolumeState(instance *v2vv1alp
 	// If all DVs was imported - update state
 	allDone := done == numberOfDvs
 	if allDone && !conditions.HasSucceededConditionOfReason(instance.Status.Conditions, v2vv1alpha1.VirtualMachineReady, v2vv1alpha1.VirtualMachineRunning) {
-		cond := conditions.NewSucceededCondition(string(v2vv1alpha1.VirtualMachineReady), "Virtual machine disks import done", corev1.ConditionTrue)
-		vmImportName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
-		if err := r.upsertStatusCondition(vmImportName, cond); err != nil {
+		if err := r.updateConditionsAfterSuccess(instance, "Virtual machine disks import done", v2vv1alpha1.VirtualMachineReady); err != nil {
 			return err
 		}
 	}
@@ -379,8 +392,8 @@ func (r *ReconcileVirtualMachineImport) manageDataVolumeState(instance *v2vv1alp
 func (r *ReconcileVirtualMachineImport) createDataVolumes(provider provider.Provider, instance *v2vv1alpha1.VirtualMachineImport, dvs map[string]cdiv1.DataVolume, vmName types.NamespacedName) error {
 	instanceNamespacedName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 	// Update condition to create VM:
-	cond := conditions.NewProcessingCondition(string(v2vv1alpha1.CopyingDisks), "Copying virtual machine disks")
-	err := r.upsertStatusCondition(instanceNamespacedName, cond)
+	processingCond := conditions.NewProcessingCondition(string(v2vv1alpha1.CopyingDisks), "Copying virtual machine disks", corev1.ConditionTrue)
+	err := r.upsertStatusConditions(instanceNamespacedName, processingCond)
 	if err != nil {
 		return err
 	}
@@ -404,9 +417,9 @@ func (r *ReconcileVirtualMachineImport) createDataVolumes(provider provider.Prov
 		err = r.client.Create(context.TODO(), &dv)
 		if err != nil {
 			// Update condition to failed:
-			cond = conditions.NewSucceededCondition(string(v2vv1alpha1.DataVolumeCreationFailed), fmt.Sprintf("Data volume creation failed: %s", err), corev1.ConditionFalse)
-			err = r.upsertStatusCondition(instanceNamespacedName, cond)
-			if err != nil {
+			succeededCond := conditions.NewSucceededCondition(string(v2vv1alpha1.DataVolumeCreationFailed), fmt.Sprintf("Data volume creation failed: %s", err), corev1.ConditionFalse)
+			processingCond.Status = corev1.ConditionFalse
+			if err = r.upsertStatusConditions(instanceNamespacedName, processingCond, succeededCond); err != nil {
 				return err
 			}
 
@@ -545,7 +558,7 @@ func (r *ReconcileVirtualMachineImport) updateTargetVMName(vmiName types.Namespa
 	return nil
 }
 
-func (r *ReconcileVirtualMachineImport) upsertStatusConditions(vmiName types.NamespacedName, newConditions []v2vv1alpha1.VirtualMachineImportCondition) error {
+func (r *ReconcileVirtualMachineImport) upsertStatusConditions(vmiName types.NamespacedName, newConditions ...v2vv1alpha1.VirtualMachineImportCondition) error {
 	var instance v2vv1alpha1.VirtualMachineImport
 	err := r.client.Get(context.TODO(), vmiName, &instance)
 	if err != nil {
@@ -664,10 +677,6 @@ func foldErrors(errs []error, prefix string, vmiName types.NamespacedName) error
 	return fmt.Errorf("%s clean-up for %v failed: %s", prefix, utils.ToLoggableResourceName(vmiName.Name, &vmiName.Namespace), message)
 }
 
-func (r *ReconcileVirtualMachineImport) upsertStatusCondition(vmiName types.NamespacedName, newCondition v2vv1alpha1.VirtualMachineImportCondition) error {
-	return r.upsertStatusConditions(vmiName, []v2vv1alpha1.VirtualMachineImportCondition{newCondition})
-}
-
 func shouldFailWith(conditions []v2vv1alpha1.VirtualMachineImportCondition) (bool, string) {
 	var message string
 	valid := true
@@ -720,7 +729,7 @@ func (r *ReconcileVirtualMachineImport) validate(instance *v2vv1alpha1.VirtualMa
 		if err != nil {
 			return true, err
 		}
-		err = r.upsertStatusConditions(types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, conditions)
+		err = r.upsertStatusConditions(types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, conditions...)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -468,9 +468,9 @@ func (r *ReconcileVirtualMachineImport) fetchResourceMapping(resourceMappingID *
 
 func shouldValidate(vmiStatus *v2vv1alpha1.VirtualMachineImportStatus) bool {
 	validCondition := conditions.FindConditionOfType(vmiStatus.Conditions, v2vv1alpha1.Valid)
-	rulesCheckingCondition := conditions.FindConditionOfType(vmiStatus.Conditions, v2vv1alpha1.MappingRulesChecking)
+	rulesVerificationCondition := conditions.FindConditionOfType(vmiStatus.Conditions, v2vv1alpha1.MappingRulesVerified)
 
-	return isIncomplete(validCondition) || isIncomplete(rulesCheckingCondition)
+	return isIncomplete(validCondition) || isIncomplete(rulesVerificationCondition)
 }
 
 func isIncomplete(condition *v2vv1alpha1.VirtualMachineImportCondition) bool {

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -227,11 +227,11 @@ var _ = Describe("Reconcile steps", func() {
 			conditions := []v2vv1alpha1.VirtualMachineImportCondition{}
 			conditions = append(conditions, v2vv1alpha1.VirtualMachineImportCondition{
 				Status: corev1.ConditionTrue,
-				Type:   v2vv1alpha1.Validating,
+				Type:   v2vv1alpha1.Valid,
 			})
 			conditions = append(conditions, v2vv1alpha1.VirtualMachineImportCondition{
 				Status: corev1.ConditionTrue,
-				Type:   v2vv1alpha1.MappingRulesChecking,
+				Type:   v2vv1alpha1.MappingRulesVerified,
 			})
 			instance.Status.Conditions = conditions
 

--- a/pkg/providers/ovirt/validation/vm-import-validation.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation.go
@@ -25,9 +25,9 @@ const (
 	warn  = 1
 	block = 2
 
-	warnReason  = string(v2vv1alpha1.MappingRulesCheckingReportedWarnings)
-	errorReason = string(v2vv1alpha1.MappingRulesCheckingFailed)
-	okReason    = string(v2vv1alpha1.MappingRulesCheckingCompleted)
+	warnReason  = string(v2vv1alpha1.MappingRulesVerificationReportedWarnings)
+	errorReason = string(v2vv1alpha1.MappingRulesVerificationFailed)
+	okReason    = string(v2vv1alpha1.MappingRulesVerificationCompleted)
 
 	incompleteMappingRulesReason = string(v2vv1alpha1.IncompleteMappingRules)
 	validationCompletedReason    = string(v2vv1alpha1.ValidationCompleted)
@@ -181,10 +181,10 @@ func (validator *VirtualMachineImportValidator) processValidationFailures(failur
 	}
 
 	if !valid {
-		return conditions.NewCondition(v2vv1alpha1.MappingRulesChecking, errorReason, errorMessage, v1.ConditionFalse)
+		return conditions.NewCondition(v2vv1alpha1.MappingRulesVerified, errorReason, errorMessage, v1.ConditionFalse)
 	} else if warnMessage != "" {
-		return conditions.NewCondition(v2vv1alpha1.MappingRulesChecking, warnReason, warnMessage, v1.ConditionTrue)
+		return conditions.NewCondition(v2vv1alpha1.MappingRulesVerified, warnReason, warnMessage, v1.ConditionTrue)
 	} else {
-		return conditions.NewCondition(v2vv1alpha1.MappingRulesChecking, okReason, "All mapping rules checks passed", v1.ConditionTrue)
+		return conditions.NewCondition(v2vv1alpha1.MappingRulesVerified, okReason, "All mapping rules checks passed", v1.ConditionTrue)
 	}
 }

--- a/pkg/providers/ovirt/validation/vm-import-validation.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation.go
@@ -159,9 +159,9 @@ func (validator *VirtualMachineImportValidator) processMappingValidationFailures
 		message = utils.WithMessage(message, failure.Message)
 	}
 	if len(failures) > 0 {
-		return conditions.NewCondition(v2vv1alpha1.Validating, incompleteMappingRulesReason, message, v1.ConditionFalse)
+		return conditions.NewCondition(v2vv1alpha1.Valid, incompleteMappingRulesReason, message, v1.ConditionFalse)
 	}
-	return conditions.NewCondition(v2vv1alpha1.Validating, validationCompletedReason, "Validating completed successfully", v1.ConditionTrue)
+	return conditions.NewCondition(v2vv1alpha1.Valid, validationCompletedReason, "Validation completed successfully", v1.ConditionTrue)
 }
 
 func (validator *VirtualMachineImportValidator) processValidationFailures(failures []validators.ValidationFailure, vmiCrName *types.NamespacedName) v2vv1alpha1.VirtualMachineImportCondition {

--- a/pkg/providers/ovirt/validation/vm-import-validation_test.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	warnReason  = string(v2vv1alpha1.MappingRulesCheckingReportedWarnings)
-	errorReason = string(v2vv1alpha1.MappingRulesCheckingFailed)
-	okReason    = string(v2vv1alpha1.MappingRulesCheckingCompleted)
+	warnReason  = string(v2vv1alpha1.MappingRulesVerificationReportedWarnings)
+	errorReason = string(v2vv1alpha1.MappingRulesVerificationFailed)
+	okReason    = string(v2vv1alpha1.MappingRulesVerificationCompleted)
 
 	incompleteMappingRulesReason = string(v2vv1alpha1.IncompleteMappingRules)
 	validationCompletedReason    = string(v2vv1alpha1.ValidationCompleted)
@@ -61,7 +61,7 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		By("having positive status of the mapping rules checking condition")
 		condition = conditions[1]
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Reason).To(Equal(okReason))
 	})
@@ -76,8 +76,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Reason).To(Equal(okReason))
 	},
@@ -111,8 +111,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(warnReason))
@@ -137,8 +137,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionFalse))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(errorReason))
@@ -162,8 +162,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Reason).To(BeEquivalentTo(okReason))
 
@@ -182,8 +182,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(warnReason))
@@ -204,8 +204,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionFalse))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(errorReason))
@@ -224,8 +224,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Reason).To(Equal(okReason))
 
@@ -247,8 +247,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(warnReason))
@@ -266,8 +266,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionFalse))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(errorReason))
@@ -328,8 +328,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesChecking)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesChecking))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.MappingRulesVerified)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.MappingRulesVerified))
 		Expect(condition.Status).To(Equal(v1.ConditionFalse))
 		Expect(*condition.Message).To(ContainSubstring(storageFailure1.Message))
 		Expect(*condition.Message).To(ContainSubstring(storageFailure2.Message))

--- a/pkg/providers/ovirt/validation/vm-import-validation_test.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 		Expect(conditions).To(HaveLen(2))
 		By("having positive status of the validation condition")
 		condition := conditions[0]
-		Expect(condition.Type).To(Equal(v2vv1alpha1.Validating))
+		Expect(condition.Type).To(Equal(v2vv1alpha1.Valid))
 		Expect(condition.Status).To(Equal(v1.ConditionTrue))
 		Expect(*condition.Reason).To(Equal(validationCompletedReason))
 
@@ -354,8 +354,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.Validating)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.Validating))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.Valid)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.Valid))
 		Expect(condition.Status).To(Equal(v1.ConditionFalse))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(incompleteMappingRulesReason))
@@ -379,8 +379,8 @@ var _ = Describe("Validating VirtualMachineImport Admitter", func() {
 
 		result := vmImportValidator.Validate(vm, crName, newOvirtMappings())
 
-		condition := conditions.FindConditionOfType(result, v2vv1alpha1.Validating)
-		Expect(condition.Type).To(Equal(v2vv1alpha1.Validating))
+		condition := conditions.FindConditionOfType(result, v2vv1alpha1.Valid)
+		Expect(condition.Type).To(Equal(v2vv1alpha1.Valid))
 		Expect(condition.Status).To(Equal(v1.ConditionFalse))
 		Expect(*condition.Message).To(ContainSubstring(message))
 		Expect(*condition.Reason).To(Equal(incompleteMappingRulesReason))


### PR DESCRIPTION
This PR introduces following changes:
 - `Validating` condition status becomes `Valid`;
 - `MappingRulesChecking` condition status becomes `MappingRulesVerified`;
 -  Releated condition status reasons are renamed;
 -  When import ends (either positively or negatively, `Processing` condition has its status set to `False` to indicate that the operator is no longer processing the CR.

Fixes #75 

```release-note
NONE
```