### PR TITLE
Add permissions to finalizers of vm

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -64,6 +64,7 @@ rules:
   - kubevirt.io
   resources:
   - 'virtualmachines'
+  - 'virtualmachines/finalizers'
   - 'virtualmachineinstances'
   verbs:
   - '*'


### PR DESCRIPTION
This PR get rid of the error log line:
```
{"level":"error","ts":1586971200.1071177,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"virtualmachineimport-controller","request":"default/vm-import-acirrosvm-swrs9","error":"datavolumes.cdi.kubevirt.io \"64302e7f-3f08-4d32-9fe1-59b6c383acb5\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tvm-import-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tvm-import-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tvm-import-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tvm-import-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\tvm-import-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tvm-import-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\tvm-import-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

Signed-off-by: Ondra Machacek <omachace@redhat.com>