### PR TITLE
Fix data volume issues

### DIFF
--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -37,6 +37,7 @@ const (
 	ovirtSecretKey = "ovirt"
 	keyAccessKey   = "accessKeyId"
 	keySecretKey   = "secretKey"
+	diskNameFormat = "disk-%v"
 )
 
 var (
@@ -208,7 +209,7 @@ func (o *OvirtProvider) UpdateVM(vmspec *kubevirtv1.VirtualMachine, dvs map[stri
 	i := 0
 	for _, dv := range dvs {
 		volumes[i] = kubevirtv1.Volume{
-			Name: fmt.Sprintf("dv-%v", i),
+			Name: fmt.Sprintf(diskNameFormat, i),
 			VolumeSource: kubevirtv1.VolumeSource{
 				DataVolume: &kubevirtv1.DataVolumeSource{
 					Name: dv.Name,
@@ -223,7 +224,7 @@ func (o *OvirtProvider) UpdateVM(vmspec *kubevirtv1.VirtualMachine, dvs map[stri
 	for id := range dvs {
 		diskAttachment := getDiskAttachmentByID(id, o.vm.MustDiskAttachments())
 		disks[i] = kubevirtv1.Disk{
-			Name: fmt.Sprintf("dv-%v", i),
+			Name: fmt.Sprintf(diskNameFormat, i),
 			DiskDevice: kubevirtv1.DiskDevice{
 				Disk: &kubevirtv1.DiskTarget{
 					Bus: string(diskAttachment.MustInterface()),

--- a/pkg/templates/template-handler.go
+++ b/pkg/templates/template-handler.go
@@ -13,9 +13,6 @@ const (
 
 	// templateNameLabel defines a label of the template name which was used to created the VM
 	templateNameLabel = "vm.kubevirt.io/template"
-
-	// templateNamespaceLabel defines a label of the template namespace which was used to created the VM
-	templateNamespaceLabel = "vm.kubevirt.io/template-namespace"
 )
 
 // TemplateHandler attempts to process templates based on given parameters
@@ -69,5 +66,4 @@ func addLabels(vm *kubevirtv1.VirtualMachine, template *templatev1.Template) {
 		vm.ObjectMeta.SetLabels(labels)
 	}
 	labels[templateNameLabel] = template.GetObjectMeta().GetName()
-	labels[templateNamespaceLabel] = template.GetObjectMeta().GetNamespace()
 }


### PR DESCRIPTION
* Replaces the prefix used for data-volumes from `dv-` to `disk-`
* Supports import of a virtual machine without disks
* Let template-validator validate the VM by eliminating the namespace from VM label
* Fixes update failure due to working on an obsolete copy of the resource:
```
{"component":"virt-controller","level":"info","msg":"re-enqueuing VirtualMachine default/examplevm","pos":"vm.go:143","reason":"Operation cannot be fulfilled on virtualmachines.kubevirt.io \"examplevm\": the object has been modified; please apply your changes to the latest version and try again","service":"http","timestamp":"2020-04-20T01:01:15.381047Z"}
```


Fixes #94 
Fixes #106 
