### PR TITLE
Allow targetVmName to be optional

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -33,7 +33,7 @@ var (
 	statusPatch        func(ctx context.Context, obj runtime.Object, patch client.Patch) error
 	getVMStatus        func() (provider.VMStatus, error)
 	findTemplate       func() (*oapiv1.Template, error)
-	processTemplate    func(template *oapiv1.Template, name string) (*kubevirtv1.VirtualMachine, error)
+	processTemplate    func(template *oapiv1.Template, name *string) (*kubevirtv1.VirtualMachine, error)
 	create             func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error
 	cleanUp            func() error
 	update             func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error
@@ -322,7 +322,7 @@ var _ = Describe("Reconcile steps", func() {
 			findTemplate = func() (*oapiv1.Template, error) {
 				return &oapiv1.Template{}, nil
 			}
-			processTemplate = func(template *oapiv1.Template, name string) (*kubevirtv1.VirtualMachine, error) {
+			processTemplate = func(template *oapiv1.Template, name *string) (*kubevirtv1.VirtualMachine, error) {
 				return &kubevirtv1.VirtualMachine{}, nil
 			}
 			mapper = &mockMapper{}
@@ -349,7 +349,7 @@ var _ = Describe("Reconcile steps", func() {
 		})
 
 		It("should fail to update condition: ", func() {
-			processTemplate = func(template *oapiv1.Template, name string) (*kubevirtv1.VirtualMachine, error) {
+			processTemplate = func(template *oapiv1.Template, name *string) (*kubevirtv1.VirtualMachine, error) {
 				return nil, fmt.Errorf("Failed")
 			}
 			statusPatch = func(ctx context.Context, obj runtime.Object, patch client.Patch) error {
@@ -920,13 +920,18 @@ func (p *mockProvider) FindTemplate() (*oapiv1.Template, error) {
 }
 
 // ProcessTemplate implements Provider.ProcessTemplate
-func (p *mockProvider) ProcessTemplate(template *oapiv1.Template, name string) (*kubevirtv1.VirtualMachine, error) {
+func (p *mockProvider) ProcessTemplate(template *oapiv1.Template, name *string) (*kubevirtv1.VirtualMachine, error) {
 	return processTemplate(template, name)
 }
 
 // CreateEmptyVM implements Mapper.CreateEmptyVM
 func (m *mockMapper) CreateEmptyVM() *kubevirtv1.VirtualMachine {
 	return &kubevirtv1.VirtualMachine{}
+}
+
+// ResolveVMName implements Mapper.ResolveVMName
+func (m *mockMapper) ResolveVMName(targetVMName *string) *string {
+	return targetVMName
 }
 
 // MapVM implements Mapper.MapVM

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -189,7 +189,7 @@ func (o *OvirtProvider) FindTemplate() (*templatev1.Template, error) {
 }
 
 // ProcessTemplate uses openshift api to process template
-func (o *OvirtProvider) ProcessTemplate(template *templatev1.Template, vmName string) (*kubevirtv1.VirtualMachine, error) {
+func (o *OvirtProvider) ProcessTemplate(template *templatev1.Template, vmName *string) (*kubevirtv1.VirtualMachine, error) {
 	return o.templateHandler.ProcessTemplate(template, vmName)
 }
 

--- a/pkg/providers/ovirt/templates/template-finder_test.go
+++ b/pkg/providers/ovirt/templates/template-finder_test.go
@@ -103,7 +103,7 @@ func (t *mockTemplateProvider) Find(
 }
 
 // Process mocks the behavior of the client for calling process API
-func (t *mockTemplateProvider) Process(namespace string, vmName string, template *templatev1.Template) (*templatev1.Template, error) {
+func (t *mockTemplateProvider) Process(namespace string, vmName *string, template *templatev1.Template) (*templatev1.Template, error) {
 	return &templatev1.Template{}, nil
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -29,12 +29,13 @@ type Provider interface {
 	StartVM() error
 	CleanUp() error
 	FindTemplate() (*oapiv1.Template, error)
-	ProcessTemplate(*oapiv1.Template, string) (*kubevirtv1.VirtualMachine, error)
+	ProcessTemplate(*oapiv1.Template, *string) (*kubevirtv1.VirtualMachine, error)
 }
 
 // Mapper is interface to be used for mapping external VM to kubevirt VM
 type Mapper interface {
 	CreateEmptyVM() *kubevirtv1.VirtualMachine
+	ResolveVMName(targetVMName *string) *string
 	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
 	MapDisks() (map[string]cdiv1.DataVolume, error)
 }

--- a/pkg/templates/template-handler.go
+++ b/pkg/templates/template-handler.go
@@ -28,7 +28,7 @@ func NewTemplateHandler(templateProvider TemplateProvider) *TemplateHandler {
 }
 
 // ProcessTemplate processes template with provided parameter values
-func (f *TemplateHandler) ProcessTemplate(template *templatev1.Template, vmName string) (*kubevirtv1.VirtualMachine, error) {
+func (f *TemplateHandler) ProcessTemplate(template *templatev1.Template, vmName *string) (*kubevirtv1.VirtualMachine, error) {
 	processed, err := f.templateProvider.Process(TemplateNamespace, vmName, template)
 	if err != nil {
 		return nil, err

--- a/pkg/templates/template-provider.go
+++ b/pkg/templates/template-provider.go
@@ -33,7 +33,7 @@ type Templates struct {
 // TemplateProvider searches for and processes templates in Openshift
 type TemplateProvider interface {
 	Find(namespace *string, os *string, workload *string, flavor *string) (*templatev1.TemplateList, error)
-	Process(namespace string, vmName string, template *templatev1.Template) (*templatev1.Template, error)
+	Process(namespace string, vmName *string, template *templatev1.Template) (*templatev1.Template, error)
 }
 
 // NewTemplateProvider creates new TemplateProvider
@@ -53,12 +53,14 @@ func (t *Templates) Find(namespace *string, os *string, workload *string, flavor
 }
 
 // Process calls the openshift api to process parameters
-func (t *Templates) Process(namespace string, vmName string, template *templatev1.Template) (*templatev1.Template, error) {
+func (t *Templates) Process(namespace string, vmName *string, template *templatev1.Template) (*templatev1.Template, error) {
 	temp := template.DeepCopy()
 	params := temp.Parameters
 	for i, param := range params {
 		if param.Name == nameParameter {
-			temp.Parameters[i].Value = vmName
+			if vmName != nil {
+				temp.Parameters[i].Value = *vmName
+			}
 		} else {
 			temp.Parameters[i].Value = otherValue
 		}


### PR DESCRIPTION
According to the design of vmimport operator, targetVmName is an
optional attribute of the vmimport resource.
The VM name will be set according to the following order:
1. targetVmName attribute from vmimport resource
2. Normalized source VM name
3. When template is available, use template generated name.
4. When template is not found, use "ovirt-" as a prefix of the generated name

Signed-off-by: Moti Asayag <masayag@redhat.com>