### PR TITLE
Add map disk interface method

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -610,12 +610,14 @@ var _ = Describe("Reconcile steps", func() {
 
 	Describe("createDataVolumes step", func() {
 		var (
-			dvs map[string]cdiv1.DataVolume
+			dvs    map[string]cdiv1.DataVolume
+			mapper provider.Mapper
 		)
 		BeforeEach(func() {
 			update = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 				return nil
 			}
+			mapper = &mockMapper{}
 			dvs = map[string]cdiv1.DataVolume{}
 		})
 
@@ -623,8 +625,7 @@ var _ = Describe("Reconcile steps", func() {
 			statusPatch = func(ctx context.Context, obj runtime.Object, patch client.Patch) error {
 				return fmt.Errorf("Not modified")
 			}
-
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -639,7 +640,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -658,7 +659,7 @@ var _ = Describe("Reconcile steps", func() {
 			}
 			dvs["test"] = cdiv1.DataVolume{}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -672,7 +673,7 @@ var _ = Describe("Reconcile steps", func() {
 			}
 			dvs["test"] = cdiv1.DataVolume{}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -688,7 +689,7 @@ var _ = Describe("Reconcile steps", func() {
 			}
 			dvs["test"] = cdiv1.DataVolume{}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -704,7 +705,7 @@ var _ = Describe("Reconcile steps", func() {
 			}
 			dvs["test"] = cdiv1.DataVolume{}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -732,7 +733,7 @@ var _ = Describe("Reconcile steps", func() {
 
 			dvs["test"] = cdiv1.DataVolume{}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -755,7 +756,7 @@ var _ = Describe("Reconcile steps", func() {
 
 			dvs["test"] = cdiv1.DataVolume{}
 
-			err := reconciler.createDataVolumes(mock, instance, dvs, vmName)
+			err := reconciler.createDataVolumes(mock, mapper, instance, dvs, vmName)
 
 			Expect(err).To(BeNil())
 		})
@@ -1350,9 +1351,13 @@ func (m *mockMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachi
 	return vmSpec, nil
 }
 
-// MapDisks implements Mapper.MapDisks
-func (m *mockMapper) MapDisks() (map[string]cdiv1.DataVolume, error) {
-	return mapDisks()
+// MapDataVolumes implements Mapper.MapDataVolumes
+func (m *mockMapper) MapDataVolumes() (map[string]cdiv1.DataVolume, error) {
+	return map[string]cdiv1.DataVolume{"123": {}}, nil
+}
+
+// MapDisks implements Mapper.MapDataVolumes
+func (m *mockMapper) MapDisks(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume) {
 }
 
 // NewOvirtClient implements Factory.NewOvirtClient

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -187,7 +187,7 @@ func (o *OvirtMapper) MapDisks(vmSpec *kubevirtv1.VirtualMachine, dvs map[string
 			Name: fmt.Sprintf("dv-%v", i),
 			DiskDevice: kubevirtv1.DiskDevice{
 				Disk: &kubevirtv1.DiskTarget{
-					Bus: string(iface),
+					Bus: o.mapDiskInterface(iface),
 				},
 			},
 		}
@@ -201,6 +201,13 @@ func (o *OvirtMapper) MapDisks(vmSpec *kubevirtv1.VirtualMachine, dvs map[string
 
 	vmSpec.Spec.Template.Spec.Volumes = volumes
 	vmSpec.Spec.Template.Spec.Domain.Devices.Disks = disks
+}
+
+func (o *OvirtMapper) mapDiskInterface(iface ovirtsdk.DiskInterface) string {
+	if iface == ovirtsdk.DISKINTERFACE_VIRTIO_SCSI {
+		return string(ovirtsdk.DISKINTERFACE_VIRTIO)
+	}
+	return string(iface)
 }
 
 // MapDataVolumes map the oVirt VM disks to the map of CDI DataVolumes specification, where

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -159,9 +159,51 @@ func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMach
 	return vmSpec, nil
 }
 
-// MapDisks map the oVirt VM disks to the map of CDI DataVolumes specification, where
+// MapDisks map VM disks
+func (o *OvirtMapper) MapDisks(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume) {
+	// Map volumes
+	volumes := make([]kubevirtv1.Volume, len(dvs))
+	i := 0
+	for _, dv := range dvs {
+		volumes[i] = kubevirtv1.Volume{
+			Name: fmt.Sprintf("dv-%v", i),
+			VolumeSource: kubevirtv1.VolumeSource{
+				DataVolume: &kubevirtv1.DataVolumeSource{
+					Name: dv.Name,
+				},
+			},
+		}
+		i++
+	}
+
+	// Map disks
+	i = 0
+	disks := make([]kubevirtv1.Disk, len(dvs))
+	for id := range dvs {
+		diskAttachment := getDiskAttachmentByID(id, o.vm.MustDiskAttachments())
+		disks[i] = kubevirtv1.Disk{
+			Name: fmt.Sprintf("dv-%v", i),
+			DiskDevice: kubevirtv1.DiskDevice{
+				Disk: &kubevirtv1.DiskTarget{
+					Bus: string(diskAttachment.MustInterface()),
+				},
+			},
+		}
+		if diskAttachment.MustBootable() {
+			bootOrder := uint(1)
+			disks[i].BootOrder = &bootOrder
+		}
+
+		i++
+	}
+
+	vmSpec.Spec.Template.Spec.Volumes = volumes
+	vmSpec.Spec.Template.Spec.Domain.Devices.Disks = disks
+}
+
+// MapDataVolumes map the oVirt VM disks to the map of CDI DataVolumes specification, where
 // map id is the id of the oVirt disk
-func (o *OvirtMapper) MapDisks() (map[string]cdiv1.DataVolume, error) {
+func (o *OvirtMapper) MapDataVolumes() (map[string]cdiv1.DataVolume, error) {
 	// TODO: stateless, boot_devices, floppy/cdrom
 	diskAttachments, _ := o.vm.DiskAttachments()
 	dvs := make(map[string]cdiv1.DataVolume, len(diskAttachments.Slice()))
@@ -614,4 +656,13 @@ func (o *OvirtMapper) mapTimeZone() *kubevirtv1.Clock {
 	clock.UTC = &offset
 
 	return &clock
+}
+
+func getDiskAttachmentByID(id string, diskAttachments *ovirtsdk.DiskAttachmentSlice) *ovirtsdk.DiskAttachment {
+	for _, diskAttachment := range diskAttachments.Slice() {
+		if diskAttachment.MustId() == id {
+			return diskAttachment
+		}
+	}
+	return nil
 }

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Test mapping disks", func() {
 		namespace := "the-namespace"
 		mapper := mapper.NewOvirtMapper(vm, &mappings, credentials, namespace)
 		daName := "123"
-		dvs, _ := mapper.MapDisks()
+		dvs, _ := mapper.MapDataVolumes()
 
 		Expect(dvs).To(HaveLen(1))
 		Expect(dvs).To(HaveKey(daName))
@@ -229,7 +229,7 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
 
-		dvs, _ := mapper.MapDisks()
+		dvs, _ := mapper.MapDataVolumes()
 
 		Expect(dvs).To(HaveLen(1))
 		Expect(dvs["123"].Spec.PVC.StorageClassName).To(Not(BeNil()))
@@ -255,7 +255,7 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
 
-		dvs, err := mapper.MapDisks()
+		dvs, err := mapper.MapDataVolumes()
 
 		Expect(err).To(BeNil())
 		Expect(dvs).To(HaveLen(1))
@@ -280,7 +280,7 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
 
-		dvs, err := mapper.MapDisks()
+		dvs, err := mapper.MapDataVolumes()
 
 		Expect(err).To(BeNil())
 		Expect(dvs).To(HaveLen(1))
@@ -293,7 +293,7 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "")
 
-		dvs, err := mapper.MapDisks()
+		dvs, err := mapper.MapDataVolumes()
 
 		Expect(err).To(BeNil())
 		Expect(dvs).To(HaveLen(1))

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -23,7 +23,6 @@ type Provider interface {
 	PrepareResourceMapping(*v2vv1alpha1.ResourceMappingSpec, v2vv1alpha1.VirtualMachineImportSourceSpec)
 	Validate() ([]v2vv1alpha1.VirtualMachineImportCondition, error)
 	StopVM() error
-	UpdateVM(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume)
 	CreateMapper() (Mapper, error)
 	GetVMStatus() (VMStatus, error)
 	StartVM() error
@@ -37,7 +36,8 @@ type Mapper interface {
 	CreateEmptyVM() *kubevirtv1.VirtualMachine
 	ResolveVMName(targetVMName *string) *string
 	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
-	MapDisks() (map[string]cdiv1.DataVolume, error)
+	MapDataVolumes() (map[string]cdiv1.DataVolume, error)
+	MapDisks(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume)
 }
 
 // VMStatus represents VM status


### PR DESCRIPTION
This PR changes:
 - remove Must methods
 - Refactor disk mapping
 - add disk interface method (so we can map `virtio_scsi` for example)