### PR TITLE
Change operator role to cluster role

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Operator which imports a VM from oVirt to KubeVirt.
 kubectl create -f deploy/crds/v2v_v1alpha1_resourcemapping_crd.yaml
 kubectl create -f deploy/crds/v2v_v1alpha1_virtualmachineimport_crd.yaml
 kubectl create -f deploy/service_account.yaml
-kubectl create -f deploy/role.yaml
-kubectl create -f deploy/role_binding.yaml
+kubectl create -f deploy/cluster_role.yaml
+
+# replace REPLACE_NAMESPACE with target namespace
+kubectl create -f deploy/cluster_role_binding.yaml
 kubectl create -f deploy/config_map.yaml
 kubectl create -f deploy/operator.yaml
 ```

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: vm-import-operator

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vm-import-operator
 subjects:
 - kind: ServiceAccount
   name: vm-import-operator
+  namespace: REPLACE_NAMESPACE
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: vm-import-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,9 +22,6 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
In order to watch any namespace for vmimport resources, the operator
RBAC should be set as a cluster-role.

Fixes #141

Signed-off-by: Moti Asayag <masayag@redhat.com>