### PR TITLE
Add storage.k8s.io/storageclasses privileges to vm-import-operator cluster role

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -86,3 +86,11 @@ rules:
   - processedtemplates
   verbs:
   - 'create'
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Waiting for #142 to be merged first. 

Fixes #132 

```release-notes
NONE
```