### PR TITLE
Making sure that transient resources' label values are not too long

### DIFF
--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -31,10 +31,10 @@ func NewManager(client client.Client) Manager {
 func (m *Manager) FindFor(vmiCrName types.NamespacedName) (*corev1.ConfigMap, error) {
 	mapList := corev1.ConfigMapList{}
 	labels := client.MatchingLabels{
-		vmiNameLabel: utils.MakeLabelFrom(vmiCrName.Namespace, vmiCrName.Name),
+		vmiNameLabel: utils.MakeLabelFrom(vmiCrName.Name),
 	}
 
-	err := m.client.List(context.TODO(), &mapList, labels)
+	err := m.client.List(context.TODO(), &mapList, labels, client.InNamespace(vmiCrName.Namespace))
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +50,7 @@ func (m *Manager) FindFor(vmiCrName types.NamespacedName) (*corev1.ConfigMap, er
 
 // CreateFor creates given config map, overriding given Name with a generated one. The config map will be associated with vmiCrName.
 func (m *Manager) CreateFor(configMap *corev1.ConfigMap, vmiCrName types.NamespacedName) error {
+	configMap.Namespace = vmiCrName.Namespace
 	// Force generation
 	configMap.GenerateName = prefix
 	configMap.Name = ""
@@ -57,7 +58,7 @@ func (m *Manager) CreateFor(configMap *corev1.ConfigMap, vmiCrName types.Namespa
 	if configMap.Labels == nil {
 		configMap.Labels = make(map[string]string)
 	}
-	configMap.Labels[vmiNameLabel] = utils.MakeLabelFrom(vmiCrName.Namespace, vmiCrName.Name)
+	configMap.Labels[vmiNameLabel] = utils.MakeLabelFrom(vmiCrName.Name)
 
 	return m.client.Create(context.TODO(), configMap)
 }

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -24,7 +24,6 @@ import (
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -320,9 +319,6 @@ func (o *OvirtProvider) ensureSecretIsPresent(keyAccess string, keySecret string
 
 func (o *OvirtProvider) createSecret(keyAccess string, keySecret string) (*corev1.Secret, error) {
 	newSecret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: o.vmiCrName.Namespace,
-		},
 		Data: map[string][]byte{
 			keyAccessKey: []byte(keyAccess),
 			keySecretKey: []byte(keySecret),
@@ -351,9 +347,6 @@ func (o *OvirtProvider) ensureConfigMapIsPresent(caCert string) (*corev1.ConfigM
 
 func (o *OvirtProvider) createConfigMap(caCert string) (*corev1.ConfigMap, error) {
 	newConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: o.vmiCrName.Namespace,
-		},
 		Data: map[string]string{
 			"ca.pem": caCert,
 		},

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -31,10 +31,10 @@ func NewManager(client client.Client) Manager {
 func (m *Manager) FindFor(vmiCrName types.NamespacedName) (*corev1.Secret, error) {
 	secretList := corev1.SecretList{}
 	labels := client.MatchingLabels{
-		vmiNameLabel: utils.MakeLabelFrom(vmiCrName.Namespace, vmiCrName.Name),
+		vmiNameLabel: utils.MakeLabelFrom(vmiCrName.Name),
 	}
 
-	err := m.client.List(context.TODO(), &secretList, labels)
+	err := m.client.List(context.TODO(), &secretList, labels, client.InNamespace(vmiCrName.Namespace))
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +50,7 @@ func (m *Manager) FindFor(vmiCrName types.NamespacedName) (*corev1.Secret, error
 
 // CreateFor creates given secret, overriding given Name with a generated one. The secret will be associated with vmiCrName.
 func (m *Manager) CreateFor(secret *corev1.Secret, vmiCrName types.NamespacedName) error {
+	secret.Namespace = vmiCrName.Namespace
 	// Force generation
 	secret.GenerateName = prefix
 	secret.Name = ""
@@ -57,7 +58,7 @@ func (m *Manager) CreateFor(secret *corev1.Secret, vmiCrName types.NamespacedNam
 	if secret.Labels == nil {
 		secret.Labels = make(map[string]string)
 	}
-	secret.Labels[vmiNameLabel] = utils.MakeLabelFrom(vmiCrName.Namespace, vmiCrName.Name)
+	secret.Labels[vmiNameLabel] = utils.MakeLabelFrom(vmiCrName.Name)
 
 	return m.client.Create(context.TODO(), secret)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -157,6 +157,31 @@ var _ = Describe("UTC Offset string parsing", func() {
 	)
 })
 
+var _ = Describe("Label generation", func() {
+	table.DescribeTable("should generate labels being unmodified names", func(name string) {
+		label := utils.MakeLabelFrom(name)
+
+		Expect(label).To(BeEquivalentTo(name))
+	},
+
+		table.Entry("empty string", ""),
+		table.Entry("one character", "x"),
+
+		table.Entry("mid-range length", createStringOfLength(34)),
+		table.Entry("max length", createStringOfLength(63)),
+	)
+
+	table.DescribeTable("should generate labels being shortened names", func(name string, expectedName string) {
+		label := utils.MakeLabelFrom(name)
+
+		Expect(label).To(BeEquivalentTo(expectedName))
+	},
+		table.Entry("slightly longer", createStringOfLength(64), createStringOfLength(60)+"_64"),
+		table.Entry("three digits long", createStringOfLength(128), createStringOfLength(59)+"_128"),
+		table.Entry("max resource name", createStringOfLength(253), createStringOfLength(59)+"_253"),
+	)
+})
+
 func createStringOfLength(n int) string {
 	return strings.Repeat("x", n)
 }


### PR DESCRIPTION
The label values mustn't be longer than 63 characters. This PR makes sure it won't happen for our transient resources. Fixes #150 

The shortening algorithm is a bit naive and doesn't completely protect us from creating duplicated labels. 

The alternative I see is to create multiple labels containing all the 63 character long parts of the import CR name (to the max of 5 - CR name can be 253-characters long):
```yaml 
vmimport.v2v.kubevirt.io/vmi-name-1: part1
vmimport.v2v.kubevirt.io/vmi-name-2: part2
vmimport.v2v.kubevirt.io/vmi-name-3: part3
vmimport.v2v.kubevirt.io/vmi-name-4: part4
vmimport.v2v.kubevirt.io/vmi-name-5: part5
```

What do you think?

```release-notes
NONE
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>