### PR TITLE
Use vNIC Profile as source network mappings for oVirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ spec:
   ovirt:
     networkMappings:
       - source:
-          name: ovirtmgmt
+          name: ovirtmgmt/ovirtmgmt
         target:
           name: pod
         type: pod

--- a/docs/design.md
+++ b/docs/design.md
@@ -54,7 +54,7 @@ Spec:
       mappings:
         networkMappings:
         - source:
-            name: red
+            name: red/profile1
             target: xyz
             type: bridge
         diskMappings: # a mapping of a specific disk to storage class
@@ -94,6 +94,10 @@ Each section specifies the mapping between ovirt entity to kubevirt’s entity, 
 
 The import VM operator will be responsible to deduce the configuration of the target VM based on the configuration of the source and perform the transformation in a way that will preserve the attributes of the source VM, e.g. boot sequence, MAC address, [run strategy](https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/run-strategies.html), [domain specification](https://kubevirt.io/api-reference/v0.26.1/definitions.html#_v1_domainspec) and hostname if available on ovirt by the guest agent.
 
+“networkMappings“ section under “ovirt“ source describes the mapping of oVirt's vNIC Profile to network attachment definition:
+* name - should follow the format of 'network-name/vnic-profile-name'
+* id - represents the vnic-profile ID
+
 ```yaml
 apiVersion: v2v.kubevirt.io/v1alpha1
 kind: ResourceMapping
@@ -104,7 +108,7 @@ Spec:
   ovirt:
     networkMappings:
     - source:
-        name: red # maps of ovirt logic network to network attachment definition
+        name: red/profile1 # maps of ovirt 'logic network/vnic profile' to network attachment definition
       target: xyz
       type: bridge
     - source:

--- a/examples/ovirt_resourcemapping_example_cr.yaml
+++ b/examples/ovirt_resourcemapping_example_cr.yaml
@@ -7,12 +7,12 @@ spec:
   ovirt:
     networkMappings:
       - source:
-          name: red # maps of ovirt logical network to network attachment definition
+          name: red/profile1  # maps of ovirt 'logic network/vnic profile' to network attachment definition
         target:
           name: xyz
         type: bridge
       - source:
-          name: ovirtmgmt
+          name: ovirtmgmt/ovirtmgmt
         target:
           name: pod
         type: pod

--- a/pkg/apis/v2v/v1alpha1/resourcemapping_types.go
+++ b/pkg/apis/v2v/v1alpha1/resourcemapping_types.go
@@ -21,6 +21,11 @@ type ResourceMappingSpec struct {
 // OvirtMappings defines the mappings of ovirt resources to kubevirt
 // +k8s:openapi-gen=true
 type OvirtMappings struct {
+	// NetworkMappings defines the mapping of vnic profile to network attachment definition
+	// When providing source network by name, the format is 'network name/vnic profile name'.
+	// When providing source network by ID, the ID represents the vnic profile ID.
+	// A logical network from ovirt can be mapped to multiple network attachment definitions
+	// on kubevirt by using vnic profile to network attachment definition mapping.
 	// +optional
 	NetworkMappings *[]ResourceMappingItem `json:"networkMappings,omitempty"`
 

--- a/tests/cirros/mapping.yml
+++ b/tests/cirros/mapping.yml
@@ -7,7 +7,7 @@ spec:
   ovirt:
     networkMappings:
       - source:
-          name: ovirtmgmt
+          name: ovirtmgmt/ovirtmgmt
         target:
           name: pod
         type: pod


### PR DESCRIPTION
Source Network from oVirt can be mapped via vNIC Profiles to different
network attachment definition entities on KubeVirt.
Hence the semantic of the network mapping under 'ovirt' source of the
resource mappings is changed to support it.

- _ovirt.networkMappings.source.name_ expects the format of _'network-name/vnic-profile-name'_ 
- _ovirt.networkMappings.source.name_ expects the value of the vNIC Profile ID.


Fixes #111

Signed-off-by: Moti Asayag <masayag@redhat.com>
