### PR TITLE
'latest' is not a semver and cannot be used with csv-generator

### DIFF
--- a/cluster/operator-install.sh
+++ b/cluster/operator-install.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-export VERSION=latest
+export VERSION=v0.0.0
 
 ./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/operator.yaml
 ./cluster/kubectl.sh wait deploy/vm-import-operator -n kubevirt --for=condition=Available --timeout=600s

--- a/cluster/operator-push.sh
+++ b/cluster/operator-push.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-export VERSION=latest
+export VERSION=v0.0.0
 
 registry_port=$(./cluster/cli.sh ports registry | tr -d '\r')
 if [[ "${KUBEVIRT_PROVIDER}" =~ ^(okd|ocp)-.*$ ]]; then \


### PR DESCRIPTION
"'latest" is not a semver and cannot be used with csv-generator:                                                                          
```
./hack/generate-manifests.sh
panic: No Major.Minor.Patch elements found
 
goroutine 1 [running]:
main.main()
        /home/jdzon/go/src/github.com/kubevirt/vm-import-operator/tools/csv-generator/csv-generator.go:38 +0x2a1
```
```release-note
NONE
```

Signed-off-by: Jakub Dzon <jdzon@redhat.com>