### PR TITLE
Allow user to override OS Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Deploy vm-import-operator resources:
 ```bash
 kubectl apply -f https://github.com/kubevirt/vm-import-operator/releases/download/v0.0.1/v2v_v1alpha1_resourcemapping_crd.yaml
 kubectl apply -f https://github.com/kubevirt/vm-import-operator/releases/download/v0.0.1/v2v_v1alpha1_virtualmachineimport_crd.yaml
+# TODO: remove config_map.yaml once v0.0.2 is released
 kubectl apply -f https://github.com/kubevirt/vm-import-operator/releases/download/v0.0.1/config_map.yaml
 kubectl apply -f https://github.com/kubevirt/vm-import-operator/releases/download/v0.0.1/operator.yaml
 ```
@@ -144,6 +145,7 @@ kubectl logs import-vm-oprator-xyz
 ```bash
 kubectl apply -f manifests/vm-import-operator/v0.0.1/v2v_v1alpha1_resourcemapping_crd.yaml
 kubectl apply -f manifests/vm-import-operator/v0.0.1/v2v_v1alpha1_virtualmachineimport_crd.yaml
+# TODO: remove config_map.yaml once v0.0.2 is released
 kubectl apply -f manifests/vm-import-operator/v0.0.1/config_map.yaml
 kubectl apply -f manifests/vm-import-operator/v0.0.1/operator.yaml
 # since operator.yaml deploys the operator, remove it to use local one

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -21,4 +21,3 @@ echo 'Cleaning up ...'
 ./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_resourcemapping_crd.yaml
 ./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_virtualmachineimport_crd.yaml
 ./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/operator.yaml
-./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/config_map.yaml

--- a/cluster/operator-push.sh
+++ b/cluster/operator-push.sh
@@ -37,4 +37,3 @@ IMAGE_REGISTRY=$registry make docker-build docker-push
 
 ./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_resourcemapping_crd.yaml
 ./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_virtualmachineimport_crd.yaml
-./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/config_map.yaml

--- a/docs/design.md
+++ b/docs/design.md
@@ -121,6 +121,36 @@ Spec:
         name: ovirt_storage_domain_1 # maps ovirt storage domains to storage class
       target: storage_class_1
 ```
+#### Common Templates
+The operator defines a map of OS types to equivalent common templates OS types.
+When a match is found between the imported VM operating system via operator's OS map to a common template, that template will be used to create the VM spec of the target VM.
+The user can provide a custom map to override or extend operator's OS map by providing the map via environment variables to be set for the operator's deployment resource. Both OS config-map name and namespace are required:
+- OS_CONFIGMAP_NAME - the user OS config map name
+- OS_CONFIGMAP_NAMESPACE - the user OS config map namespace
+
+An example of the map can be found under [example](https://github.com/kubevirt/vm-import-operator/blob/master/examples/config_map.yaml) and should follow the format of:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmimport-os-mapper
+  namespace: kubevirt-hyperconverged
+data:
+  guestos2common: |
+    "Red Hat Enterprise Linux Server": "rhel"
+    "CentOS Linux": "centos"
+    "Fedora": "fedora"
+    "Ubuntu": "ubuntu"
+    "openSUSE": "opensuse"
+  osinfo2common: |
+    "rhel_6_9_plus_ppc64": "rhel6.9"
+    "rhel_6_ppc64": "rhel6.9"
+    "rhel_6": "rhel6.9"
+    "rhel_6x64": "rhel6.9"
+    "rhel_7_ppc64": "rhel7.7"
+```
+- guestos2common - maps the guest OS (as reported by the guest agent) to common template
+- osinfo2common - maps the operating system resource of source provider to common template
 
 ### Provider Secret
 

--- a/examples/config_map.yaml
+++ b/examples/config_map.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vmimport-os-mapper
-  namespace: {{NAMESPACE}}
+  namespace: kubevirt-hyperconverged
 data:
   guestos2common: |
     "Red Hat Enterprise Linux Server": "rhel"

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -282,6 +282,12 @@ func createEnv(name string) []corev1.EnvVar {
 			Name:  "OPERATOR_NAME",
 			Value: name,
 		},
+		corev1.EnvVar{
+			Name: "OS_CONFIGMAP_NAME",
+		},
+		corev1.EnvVar{
+			Name: "OS_CONFIGMAP_NAMESPACE",
+		},
 	}
 }
 

--- a/pkg/os/os-mapper-provider.go
+++ b/pkg/os/os-mapper-provider.go
@@ -2,18 +2,27 @@ package os
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	clientutil "kubevirt.io/client-go/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	osConfigMapName    = "vmimport-os-mapper"
-	guestOsToCommonKey = "guestos2common"
-	osInfoToCommonKey  = "osinfo2common"
+	// GuestOsToCommonKey represents the element key in OS map of guest OS to common template mapping
+	GuestOsToCommonKey = "guestos2common"
+
+	// OsInfoToCommonKey represents the element key in OS map of OS type to common template mapping
+	OsInfoToCommonKey = "osinfo2common"
+
+	// OsConfigMapName represents the environment variable name that holds the OS config map name
+	OsConfigMapName = "OS_CONFIGMAP_NAME"
+
+	// OsConfigMapNamespace represents the environment variable name that holds the OS config map namespace
+	OsConfigMapNamespace = "OS_CONFIGMAP_NAMESPACE"
 )
 
 // OSMaps is responsible for getting the operating systems maps which contain mapping of GuestOS to common templates
@@ -36,25 +45,104 @@ func NewOSMapProvider(client client.Client) *OSMaps {
 
 // GetOSMaps retrieve the OS mapping config map
 func (o *OSMaps) GetOSMaps() (map[string]string, map[string]string, error) {
+	guestOsToCommon := initGuestOsToCommon()
+	osInfoToCommon := initOsInfoToCommon()
+	err := o.updateOsMapsByUserMaps(guestOsToCommon, osInfoToCommon)
+	return guestOsToCommon, osInfoToCommon, err
+}
+
+func (o *OSMaps) updateOsMapsByUserMaps(guestOsToCommon map[string]string, osInfoToCommon map[string]string) error {
 	osConfigMap := &corev1.ConfigMap{}
-	kubevirtNamespace, _ := clientutil.GetNamespace()
+	osConfigMapName := os.Getenv(OsConfigMapName)
+	osConfigMapNamespace := os.Getenv(OsConfigMapNamespace)
+	if osConfigMapName == "" && osConfigMapNamespace == "" {
+		return nil
+	}
+
 	err := o.Client.Get(
 		context.TODO(),
-		types.NamespacedName{Name: osConfigMapName, Namespace: kubevirtNamespace},
+		types.NamespacedName{Name: osConfigMapName, Namespace: osConfigMapNamespace},
 		osConfigMap,
 	)
 	if err != nil {
-		return nil, nil, err
+		return fmt.Errorf(
+			"Failed to read user OS config-map [%s/%s] due to: [%v]",
+			osConfigMapNamespace,
+			osConfigMapName,
+			err,
+		)
 	}
-	guestOsToCommon := make(map[string]string)
-	err = yaml.Unmarshal([]byte(osConfigMap.Data[guestOsToCommonKey]), &guestOsToCommon)
+
+	err = yaml.Unmarshal([]byte(osConfigMap.Data[GuestOsToCommonKey]), &guestOsToCommon)
 	if err != nil {
-		return nil, nil, err
+		return fmt.Errorf(
+			"Failed to parse user OS config-map [%s/%s] element %s due to: [%v]",
+			osConfigMapNamespace,
+			osConfigMapName,
+			GuestOsToCommonKey,
+			err,
+		)
 	}
-	osInfoToCommon := make(map[string]string)
-	err = yaml.Unmarshal([]byte(osConfigMap.Data[osInfoToCommonKey]), &osInfoToCommon)
+
+	err = yaml.Unmarshal([]byte(osConfigMap.Data[OsInfoToCommonKey]), &osInfoToCommon)
 	if err != nil {
-		return nil, nil, err
+		return fmt.Errorf(
+			"Failed to parse user OS config-map [%s/%s] element %s due to: [%v]",
+			osConfigMapNamespace,
+			osConfigMapName,
+			OsInfoToCommonKey,
+			err,
+		)
 	}
-	return guestOsToCommon, osInfoToCommon, nil
+
+	return nil
+}
+
+func initGuestOsToCommon() map[string]string {
+	return map[string]string{
+		"Red Hat Enterprise Linux Server": "rhel",
+		"CentOS Linux":                    "centos",
+		"Fedora":                          "fedora",
+		"Ubuntu":                          "ubuntu",
+		"openSUSE":                        "opensuse",
+	}
+}
+
+func initOsInfoToCommon() map[string]string {
+	return map[string]string{
+		"rhel_6_9_plus_ppc64": "rhel6.9",
+		"rhel_6_ppc64":        "rhel6.9",
+		"rhel_6":              "rhel6.9",
+		"rhel_6x64":           "rhel6.9",
+		"rhel_7_ppc64":        "rhel7.7",
+		"rhel_7_s390x":        "rhel7.7",
+		"rhel_7x64":           "rhel7.7",
+		"rhel_8x64":           "rhel8.1",
+		"sles_11_ppc64":       "opensuse15.0",
+		"sles_11":             "opensuse15.0",
+		"sles_12_s390x":       "opensuse15.0",
+		"ubuntu_12_04":        "ubuntu18.04",
+		"ubuntu_12_10":        "ubuntu18.04",
+		"ubuntu_13_04":        "ubuntu18.04",
+		"ubuntu_13_10":        "ubuntu18.04",
+		"ubuntu_14_04_ppc64":  "ubuntu18.04",
+		"ubuntu_14_04":        "ubuntu18.04",
+		"ubuntu_16_04_s390x":  "ubuntu18.04",
+		"windows_10":          "win10",
+		"windows_10x64":       "win10",
+		"windows_2003":        "win10",
+		"windows_2003x64":     "win10",
+		"windows_2008R2x64":   "win2k8",
+		"windows_2008":        "win2k8",
+		"windows_2008x64":     "win2k8",
+		"windows_2012R2x64":   "win2k12r2",
+		"windows_2012x64":     "win2k12r2",
+		"windows_2016x64":     "win2k16",
+		"windows_2019x64":     "win2k19",
+		"windows_7":           "win10",
+		"windows_7x64":        "win10",
+		"windows_8":           "win10",
+		"windows_8x64":        "win10",
+		"windows_xp":          "win10",
+	}
 }

--- a/pkg/os/os-mapper-provider_suite_test.go
+++ b/pkg/os/os-mapper-provider_suite_test.go
@@ -1,0 +1,13 @@
+package os_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOsMapperProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OS Mapper Provider Suite")
+}

--- a/pkg/os/os-mapper-provider_test.go
+++ b/pkg/os/os-mapper-provider_test.go
@@ -1,0 +1,164 @@
+package os_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	osmap "github.com/kubevirt/vm-import-operator/pkg/os"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	get func(context.Context, client.ObjectKey, runtime.Object) error
+)
+
+var _ = Describe("OS Map Provider ", func() {
+	var (
+		mClient  *mockClient
+		osMapper *osmap.OSMaps
+	)
+
+	BeforeEach(func() {
+		mClient = &mockClient{}
+		osMapper = osmap.NewOSMapProvider(mClient)
+	})
+
+	Describe("Core OS Map only", func() {
+		It("should load OS map", func() {
+			guestOsToCommon, osInfoToCommon, err := osMapper.GetOSMaps()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(guestOsToCommon).NotTo(BeEmpty())
+			Expect(osInfoToCommon).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("User OS Map env vars set with empty value", func() {
+		BeforeEach(func() {
+			os.Setenv(osmap.OsConfigMapName, "")
+			os.Setenv(osmap.OsConfigMapNamespace, "")
+		})
+
+		It("should load OS map", func() {
+			guestOsToCommon, osInfoToCommon, err := osMapper.GetOSMaps()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(guestOsToCommon).NotTo(BeEmpty())
+			Expect(osInfoToCommon).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("User OS Map env vars set with non-empty value", func() {
+		BeforeEach(func() {
+			os.Setenv(osmap.OsConfigMapName, "osmap-name")
+			os.Setenv(osmap.OsConfigMapNamespace, "osmap-namespace")
+		})
+
+		It("should fail when user OS map does not exist", func() {
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				return fmt.Errorf("Not found")
+			}
+
+			guestOsToCommon, osInfoToCommon, err := osMapper.GetOSMaps()
+
+			Expect(err).To(HaveOccurred())
+			// core values should be loaded prior to loading user OS map data
+			Expect(guestOsToCommon).NotTo(BeEmpty())
+			Expect(osInfoToCommon).NotTo(BeEmpty())
+		})
+
+		It("should prefer user OS map values", func() {
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				obj.(*corev1.ConfigMap).Data = make(map[string]string)
+				obj.(*corev1.ConfigMap).Data[osmap.GuestOsToCommonKey] = `"Fedora": "myfedora"`
+				obj.(*corev1.ConfigMap).Data[osmap.OsInfoToCommonKey] = `"rhel_6_9_plus_ppc64": "myos"`
+				return nil
+			}
+
+			guestOsToCommon, osInfoToCommon, err := osMapper.GetOSMaps()
+
+			Expect(err).NotTo(HaveOccurred())
+			// core values should be loaded prior to loading user OS map data
+			Expect(guestOsToCommon).NotTo(BeEmpty())
+			Expect(osInfoToCommon).NotTo(BeEmpty())
+
+			// verify user values overrides core values
+			Expect(osInfoToCommon["rhel_6_9_plus_ppc64"]).To(Equal("myos"))
+			Expect(guestOsToCommon["Fedora"]).To(Equal("myfedora"))
+		})
+
+		It("should fail to parse user OS map values of Guest OS to Common", func() {
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				obj.(*corev1.ConfigMap).Data = make(map[string]string)
+				obj.(*corev1.ConfigMap).Data[osmap.GuestOsToCommonKey] = `"Fedora" = "myfedora"`
+				return nil
+			}
+
+			_, _, err := osMapper.GetOSMaps()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to parse user OS config-map"))
+		})
+
+		It("should fail to parse user OS map values of OS Info to Common", func() {
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				obj.(*corev1.ConfigMap).Data = make(map[string]string)
+				obj.(*corev1.ConfigMap).Data[osmap.OsInfoToCommonKey] = `"rhel_6_9_plus_ppc64" = "myos"`
+				return nil
+			}
+
+			_, _, err := osMapper.GetOSMaps()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to parse user OS config-map"))
+		})
+	})
+})
+
+type mockClient struct{}
+
+// Create implements client.Client
+func (c *mockClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	return nil
+}
+
+// Update implements client.Client
+func (c *mockClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+// Delete implements client.Client
+func (c *mockClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	return nil
+}
+
+// DeleteAllOf implements client.Client
+func (c *mockClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	return nil
+}
+
+// Patch implements client.Client
+func (c *mockClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+// Get implements client.Client
+func (c *mockClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	return get(ctx, key, obj)
+}
+
+// List implements client.Client
+func (c *mockClient) List(ctx context.Context, objectList runtime.Object, opts ...client.ListOption) error {
+	return nil
+}
+
+// Status implements client.StatusClient
+func (c *mockClient) Status() client.StatusWriter {
+	return nil
+}

--- a/templates/vm-import-operator/VERSION/operator.yaml.in
+++ b/templates/vm-import-operator/VERSION/operator.yaml.in
@@ -150,3 +150,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "vm-import-operator"
+            - name: OS_CONFIGMAP_NAME
+            - name: OS_CONFIGMAP_NAMESPACE


### PR DESCRIPTION
In order to simplify deployment of the operator, and due to the fact
that OS map is part of the operator, the core OS Map is being embedded
to the operator's code.

In addition, in order to allow user to specify a custom OS map (to
extend or override core OS Map), the deployment of the operator
introduces two environment variables that will be used to identify the
user OS Map by name and namespace:
- OS_CONFIGMAP_NAME
- OS_CONFIGMAP_NAMESPACE

Signed-off-by: Moti Asayag <masayag@redhat.com>