### PR TITLE
Add new information events

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -48,15 +48,19 @@ const (
 	progressForCopyDisk               = 40
 	requeueAfterValidationFailureTime = 5 * time.Second
 
-	// EventImportSucceeded is emitted
+	// EventImportScheduled is emitted when import scheduled
+	EventImportScheduled = "ImportScheduled"
+	// EventImportInProgress is emitted when import is in progress
+	EventImportInProgress = "ImportInProgress"
+	// EventImportSucceeded is emitted when import succeed
 	EventImportSucceeded = "ImportSucceeded"
-	// EventImportBlocked is emitted
+	// EventImportBlocked is emitted when import is blocked
 	EventImportBlocked = "ImportBlocked"
-	// EventVMStartFailed is emitted
+	// EventVMStartFailed is emitted when vm failed to start
 	EventVMStartFailed = "VMStartFailed"
-	// EventVMCreationFailed is emitted
+	// EventVMCreationFailed is emitted when creation of vm fails
 	EventVMCreationFailed = "VMCreationFailed"
-	// EventDVCreationFailed is emitted
+	// EventDVCreationFailed is emitted when creation of datavolume fails
 	EventDVCreationFailed = "DVCreationFailed"
 )
 
@@ -225,6 +229,8 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 			return reconcile.Result{}, err
 		}
 		vmName.Name = newName
+		// Emit event we are starting the import process:
+		r.recorder.Eventf(instance, corev1.EventTypeNormal, EventImportScheduled, "Import of Virtual Machine %s/%s started", vmName.Namespace, vmName.Name)
 	}
 
 	// Import disks:
@@ -509,6 +515,9 @@ func (r *ReconcileVirtualMachineImport) createDataVolumes(provider provider.Prov
 			return err
 		}
 	}
+
+	// Emit event that DVs import is in progress:
+	r.recorder.Eventf(instance, corev1.EventTypeNormal, EventImportInProgress, "Import of Virtual Machine %s/%s disks are in progress", vmName.Namespace, vmName.Name)
 
 	// Update datavolume in VM import CR status:
 	if err = r.updateDVs(instanceNamespacedName, dvs); err != nil {

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Reconcile steps", func() {
 			return nil
 		}
 		vmName = types.NamespacedName{Name: "test", Namespace: "default"}
-		rec := record.NewFakeRecorder(1)
+		rec := record.NewFakeRecorder(2)
 		reconciler = NewReconciler(mockClient, finder, scheme, ownerreferences.NewOwnerReferenceManager(mockClient), factory, kvConfigProviderMock, rec)
 	})
 
@@ -1022,7 +1022,7 @@ var _ = Describe("Reconcile steps", func() {
 			create = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 				return nil
 			}
-			rec := record.NewFakeRecorder(1)
+			rec := record.NewFakeRecorder(2)
 			reconciler.recorder = rec
 		})
 
@@ -1197,7 +1197,10 @@ var _ = Describe("Reconcile steps", func() {
 			result, err := reconciler.Reconcile(request)
 
 			event := <-reconciler.recorder.(*record.FakeRecorder).Events
+			Expect(event).To(ContainSubstring("started"))
+			event = <-reconciler.recorder.(*record.FakeRecorder).Events
 			Expect(event).To(ContainSubstring("creation failed"))
+
 			Expect(err).To(Not(BeNil()))
 			Expect(result).To(Equal(reconcile.Result{}))
 		})


### PR DESCRIPTION
This PR add two new events:
 1) ImportScheduled - emitted when VM is created and so disks import can
start
 2) ImportInProgress - emitted when VM disks import starts

Fixes: https://github.com/kubevirt/vm-import-operator/issues/209

```
Events:
  Type    Reason            Age                From                             Message
  ----    ------            ----               ----                             -------
  Normal  ImportScheduled   4m14s              virtualmachineimport-controller  Import of Virtual Machine default/testvm started
  Normal  ImportInProgress  4m14s              virtualmachineimport-controller  Import of Virtual Machine default/testvm disks are in progress
  Normal  ImportSucceeded   51s   virtualmachineimport-controller  Virtual Machine default/testvm import successful
```

Signed-off-by: Ondra Machacek <omachace@redhat.com>