### PR TITLE
Don't use sudo in test scripts

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -28,6 +28,6 @@ function ensure_golang {
     GOVERSION='go1.14.2.linux-amd64.tar.gz'
     if [[ "$(go version 2>&1)" =~ "not found" ]]; then
         wget https://dl.google.com/go/${GOVERSION}
-        sudo tar -C /usr/local -xzf ${GOVERSION}
+        tar -C /usr/local -xzf ${GOVERSION}
     fi
 }


### PR DESCRIPTION
Image gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9 don't have sudo
command installed, so we can't use sudo to move the go executables to
/usr/local directory. So in case on your dev-env you don't have write
permissions on /usr/local make sure to install golang manually or make
sure you have write access on /usr/local.

Signed-off-by: Ondra Machacek <omachace@redhat.com>