### PR TITLE
Add variable to change kubevirtci version

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.16'}
+export KUBEVIRTCI_VERSION=${KUBEVIRTCI_VERSION:-'master'}
 
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 
@@ -21,6 +22,7 @@ function kubevirtci::install() {
         git clone https://github.com/kubevirt/kubevirtci.git ${KUBEVIRTCI_PATH}
         (
             cd ${KUBEVIRTCI_PATH}
+            git checkout ${KUBEVIRTCI_VERSION}
         )
     fi
 }


### PR DESCRIPTION
This PR add env variable to change kubevirt ci version if needed. For
now we use master, but we can change it in case there is bug to some
older version.

Signed-off-by: Ondra Machacek <omachace@redhat.com>