### PR TITLE
Use new name format of manifest

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -18,6 +18,6 @@ set -ex
 
 echo 'Cleaning up ...'
 
-./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_resourcemapping_crd.yaml
-./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_virtualmachineimport_crd.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/resourcemapping_crd.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/virtualmachineimport_crd.yaml
 ./cluster/kubectl.sh delete --ignore-not-found -f _out/vm-import-operator/${VERSION}/operator.yaml

--- a/cluster/operator-push.sh
+++ b/cluster/operator-push.sh
@@ -35,5 +35,5 @@ make cluster-clean
 
 IMAGE_REGISTRY=$registry make docker-build docker-push
 
-./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_resourcemapping_crd.yaml
-./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/v2v_v1alpha1_virtualmachineimport_crd.yaml
+./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/resourcemapping_crd.yaml
+./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/virtualmachineimport_crd.yaml


### PR DESCRIPTION
We now use new format of name without v2v_v1alpha1 prefix, we should use
it in our tests as well.

Signed-off-by: Ondra Machacek <omachace@redhat.com>