### PR TITLE
Remove duplicated policy rule

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -155,17 +155,6 @@ func getControllerPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
-				"apps",
-			},
-			Resources: []string{
-				"replicasets",
-			},
-			Verbs: []string{
-				"get",
-			},
-		},
-		{
-			APIGroups: []string{
 				"v2v.kubevirt.io",
 			},
 			Resources: []string{


### PR DESCRIPTION
We define twice policy rule for replicasets. This PR removes duplication.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>