### PR TITLE
Set correct ns when creating serviceMonitor

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -169,7 +169,7 @@ func main() {
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
+	_, err = metrics.CreateServiceMonitors(cfg, kubevirtNamespace, services)
 	if err != nil {
 		log.Info("Could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return


### PR DESCRIPTION
With cluster scope we watch all the namespaces so we try to use "" as namespace when creating serviceMonitor. We should use operator's namespace.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>