### PR TITLE
Generate controller manifests

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -21,6 +21,7 @@ Kubernetes cluster should be available and pointed by `~/.kube/config` or by `$K
 
 #### Remote Debugging of vm-import-controller
 ```bash
+kubectl apply -f `./hack/generate-controller-manifests.sh`
 make debug-controller
 ```
 Connect to the debug session, i.e. if using vscode, create launch.json as:

--- a/hack/generate-controller-manifests.sh
+++ b/hack/generate-controller-manifests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+# The script is desinged to create conroller-related manifests.
+# The manifests will be installed to allow the controller to run without
+# the operator. This is for development purpose only.
+
+PROJECT_ROOT="$(readlink -e $(dirname "$BASH_SOURCE[0]")/..)"
+DEPLOY_DIR="${DEPLOY_DIR:-${PROJECT_ROOT}/build/_output/deploy}"
+KUBEVIRT_NAMESPACE="${REPLACE_KUBEVIRT_NAMESPACE:-kubevirt-hyperconverged}"
+
+mkdir -p $DEPLOY_DIR
+
+go build -o ${PROJECT_ROOT}/tools/csv-generator/csv-generator ${PROJECT_ROOT}/tools/csv-generator/csv-generator.go
+file="${DEPLOY_DIR}/vm-import-controller-local-manifests.yaml"
+rendered=$( \
+	${PROJECT_ROOT}/tools/csv-generator/csv-generator \
+	--namespace=${KUBEVIRT_NAMESPACE} \
+	--controller-only=true \
+)
+if [[ ! -z "$rendered" ]]; then
+	echo -e "$rendered" > $file
+fi
+
+(cd ${PROJECT_ROOT}/tools/csv-generator && go clean)
+echo $file

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -18,6 +18,7 @@ var (
 	operatorImage      = flag.String("operator-image", "", "The operator image name")
 	controllerImage    = flag.String("controller-image", "", "The controller image name")
 	dumpCRDs           = flag.Bool("dump-crds", false, "optional - dumps crd manifests to stdout")
+	controllerOnly     = flag.Bool("controller-only", false, "optional - dumps manifests to stdout only for controller local deployment")
 )
 
 func main() {
@@ -33,6 +34,34 @@ func main() {
 		OperatorVersion:    *operatorVersion,
 		OperatorImage:      *operatorImage,
 		ControllerImage:    *controllerImage,
+	}
+
+	// Generate resources required for deploying the controller only
+	if *controllerOnly {
+		err := util.MarshallObject(vmioperator.CreateResourceMapping(), os.Stdout)
+		if err != nil {
+			panic(err)
+		}
+		err = util.MarshallObject(vmioperator.CreateVMImport(), os.Stdout)
+		if err != nil {
+			panic(err)
+		}
+		err = util.MarshallObject(vmioperator.CreateServiceAccount(*namespace), os.Stdout)
+		if err != nil {
+			panic(err)
+		}
+		err = util.MarshallObject(vmioperator.CreateControllerRole(), os.Stdout)
+		if err != nil {
+			panic(err)
+		}
+		err = util.MarshallObject(vmioperator.CreateControllerRoleBinding(*namespace), os.Stdout)
+		if err != nil {
+			panic(err)
+		}
+		if err != nil {
+			panic(err)
+		}
+		return
 	}
 
 	csv, err := vmioperator.NewClusterServiceVersion(&data)


### PR DESCRIPTION
The PR adds the ability to generate manifests required for the
vm-import-controller to run locally without being managed by the
operator.

Signed-off-by: Moti Asayag <masayag@redhat.com>