### PR TITLE
Add IMPORT_POD_RESTART_TOLERANCE env var

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -394,6 +394,10 @@ func createControllerEnv(pullPolicy string) []corev1.EnvVar {
 			Name: "OS_CONFIGMAP_NAMESPACE",
 		},
 		{
+			Name:  "IMPORT_POD_RESTART_TOLERANCE",
+			Value: "3",
+		},
+		{
 			Name:  "PULL_POLICY",
 			Value: pullPolicy,
 		},


### PR DESCRIPTION
This PR add IMPORT_POD_RESTART_TOLERANCE env var which define how many
import pod restart are tolerated by the controller before we end the
import as failed.

Fixes: https://github.com/kubevirt/vm-import-operator/issues/254

Signed-off-by: Ondra Machacek <omachace@redhat.com>