### PR TITLE
Defined new VM configuration-related e2e test cases

### DIFF
--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -15,6 +15,23 @@
 | :---------------- | :-----------: |
 | Networked VM import should create started VM | &check; |
 
+## Various VM configurations
+| Test description | Implemented |
+| :---------------- | :-----------: |
+| VM with 'up' status should be imported and started | &cross; |
+| VM with 'q35_secure_boot' BIOS type should be imported and started | &cross; |
+| VM with 'q35_ovmf' BIOS type should be imported and started | &cross; |
+| VM with 'ppc64' architecture should be imported and started | &cross; |
+| VM with 'undefined' architecture should be imported and started | &cross; |
+| VM with 'ovirt' origin should be imported and started | &cross; |
+| VM with placement policy affinity set to 'user_migratable' should be imported and started | &cross; |
+| VM with placement policy affinity set to 'migrateble' and Live Migration enabled should be imported and started | &cross; |
+| VM with placement policy affinity set to 'pinned' should be imported and started | &cross; |
+| VM with UTC-compatible (i.e. 'Africa/Abidjan')  timezone should be imported and started | &cross; |
+| VM with correct pinning layout should be imported and started | &cross; |
+| VM with disabled USB should be imported and started | &cross; |
+| VM with 'i6300esb' watchdog should be imported and started | &cross; |
+
 ## Cancel VM Import
 | Test description | Implemented |
 | :---------------- | :-----------: |
@@ -51,6 +68,7 @@
 | VM with placement policy affinity set to 'migratable' should be blocked | &check; |
 | VM with USB enabled should be blocked | &check; |
 | VM with watchdog other than 'i6300esb' should be blocked | &check; |
+| VM with non-UTC-compatible (i.e. 'America/New_York')  timezone should be blocked | &cross; |
 
 ## Resource mapping
 | Test description | Implemented |
@@ -73,3 +91,9 @@
 | Import of VM should create running VM with Multus network | &check; |
 | Import of VM should create running VM with two networks: Multus and Pod | &check; |
 | Import of VM should create running VM with two Multus networks | &check; |
+
+## Templates
+| Test description | Implemented |
+| :---------------- | :---------: |
+| Import of a Windows VM should detect and apply correct template to the target VM | &cross; |
+| Import of a Linux VM should detect and apply correct template to the target VM | &cross; |


### PR DESCRIPTION
- VM configurations that are the opposites of the VM Validation test cases
- Simple templates tests

```release-notes
NONE
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>