### PR TITLE
Bump default k8s version to 1.18

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -27,6 +27,7 @@ set -ex
 # Extend path to use also local installation of the golang
 export PATH=$PATH:/usr/local/go/bin
 export KUBEVIRT_PROVIDER=$TARGET
+export KUBEVIRT_WITH_CNAO=true
 
 make cluster-down
 make cluster-up

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-function install_cnao {
-  CNAO_VERSION=${CNAO_VERSION:-'0.35.1'}
-  ./cluster/kubectl.sh apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/${CNAO_VERSION}/namespace.yaml
-  ./cluster/kubectl.sh apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/${CNAO_VERSION}/network-addons-config.crd.yaml
-  ./cluster/kubectl.sh apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/${CNAO_VERSION}/operator.yaml
-  ./cluster/kubectl.sh apply -f ./cluster/manifests/cnao.yaml
-  ./cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=600s
-}
-
 function install_cdi {
     export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.16'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.18'}
 export KUBEVIRTCI_VERSION=${KUBEVIRTCI_VERSION:-'master'}
 
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -31,8 +31,6 @@ fi
 
 ensure_golang
 
-install_cnao
-
 install_cdi
 install_kubevirt
 install_imageio


### PR DESCRIPTION
And also use integrated CNAO, instead of explicit installation.

Signed-off-by: Ondra Machacek <omachace@redhat.com>