### PR TITLE
Set unique data-volume name

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -286,7 +286,7 @@ func (r *ReconcileVirtualMachineImport) addWatchForImportPod(instance *v2vv1alph
 }
 
 func (r *ReconcileVirtualMachineImport) importDisks(provider provider.Provider, instance *v2vv1alpha1.VirtualMachineImport, mapper provider.Mapper, vmName types.NamespacedName, vmiName types.NamespacedName) error {
-	dvs, err := mapper.MapDataVolumes()
+	dvs, err := mapper.MapDataVolumes(&vmName.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -1484,7 +1484,7 @@ func (m *mockMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachi
 }
 
 // MapDataVolumes implements Mapper.MapDataVolumes
-func (m *mockMapper) MapDataVolumes() (map[string]cdiv1.DataVolume, error) {
+func (m *mockMapper) MapDataVolumes(targetVMName *string) (map[string]cdiv1.DataVolume, error) {
 	return map[string]cdiv1.DataVolume{"123": {}}, nil
 }
 

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -17,7 +17,10 @@ import (
 
 const memoryGI = 1024 * 1024 * 1024
 
-var targetVMName = "myvm"
+var (
+	targetVMName   = "myvm"
+	expectedDVName = targetVMName + "-" + "123"
+)
 
 var (
 	findOs   func(vm *ovirtsdk.Vm) (string, error)
@@ -223,8 +226,8 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		namespace := "the-namespace"
 		mapper := mapper.NewOvirtMapper(vm, &mappings, credentials, namespace, &osFinder)
-		daName := "123"
-		dvs, _ := mapper.MapDataVolumes()
+		daName := expectedDVName
+		dvs, _ := mapper.MapDataVolumes(&targetVMName)
 
 		Expect(dvs).To(HaveLen(1))
 		Expect(dvs).To(HaveKey(daName))
@@ -270,11 +273,11 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "", &osFinder)
 
-		dvs, _ := mapper.MapDataVolumes()
+		dvs, _ := mapper.MapDataVolumes(&targetVMName)
 
 		Expect(dvs).To(HaveLen(1))
-		Expect(dvs["123"].Spec.PVC.StorageClassName).To(Not(BeNil()))
-		Expect(*dvs["123"].Spec.PVC.StorageClassName).To(Equal(targetStorageClass))
+		Expect(dvs[expectedDVName].Spec.PVC.StorageClassName).To(Not(BeNil()))
+		Expect(*dvs[expectedDVName].Spec.PVC.StorageClassName).To(Equal(targetStorageClass))
 	})
 
 	It("should map empty disk storage class to nil", func() {
@@ -296,11 +299,11 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "", &osFinder)
 
-		dvs, err := mapper.MapDataVolumes()
+		dvs, err := mapper.MapDataVolumes(&targetVMName)
 
 		Expect(err).To(BeNil())
 		Expect(dvs).To(HaveLen(1))
-		Expect(dvs["123"].Spec.PVC.StorageClassName).To(BeNil())
+		Expect(dvs[expectedDVName].Spec.PVC.StorageClassName).To(BeNil())
 	})
 	It("should map empty storage domain storage class to nil", func() {
 		storageDomainName := "mystoragedomain"
@@ -321,11 +324,11 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "", &osFinder)
 
-		dvs, err := mapper.MapDataVolumes()
+		dvs, err := mapper.MapDataVolumes(&targetVMName)
 
 		Expect(err).To(BeNil())
 		Expect(dvs).To(HaveLen(1))
-		Expect(dvs["123"].Spec.PVC.StorageClassName).To(BeNil())
+		Expect(dvs[expectedDVName].Spec.PVC.StorageClassName).To(BeNil())
 	})
 	It("should map missing mapping to nil storage class", func() {
 		mappings := v2vv1alpha1.OvirtMappings{
@@ -334,11 +337,11 @@ var _ = Describe("Test mapping disks", func() {
 		}
 		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "", &osFinder)
 
-		dvs, err := mapper.MapDataVolumes()
+		dvs, err := mapper.MapDataVolumes(&targetVMName)
 
 		Expect(err).To(BeNil())
 		Expect(dvs).To(HaveLen(1))
-		Expect(dvs["123"].Spec.PVC.StorageClassName).To(BeNil())
+		Expect(dvs[expectedDVName].Spec.PVC.StorageClassName).To(BeNil())
 	})
 
 })

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -37,7 +37,7 @@ type Mapper interface {
 	CreateEmptyVM(vmName *string) *kubevirtv1.VirtualMachine
 	ResolveVMName(targetVMName *string) *string
 	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
-	MapDataVolumes() (map[string]cdiv1.DataVolume, error)
+	MapDataVolumes(targetVMName *string) (map[string]cdiv1.DataVolume, error)
 	MapDisks(vmSpec *kubevirtv1.VirtualMachine, dvs map[string]cdiv1.DataVolume)
 }
 


### PR DESCRIPTION
Setting data-volume name as `target-vm-name + "-" + disk-attachment-id`
will assure that the DV name is unique.
This will allow importing the same disk or the same vm with a different
target name.

Using 'GenerateName' option is problematic, since there is certain
logic that relies on a known and consistent DV Name prior to its
creation.

Fixes #165

Signed-off-by: Moti Asayag <masayag@redhat.com>