### PR TITLE
Remove non-cluster roles and rolebindings from cleanup logic

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -489,8 +489,6 @@ func (r *ReconcileVMImportConfig) cleanupUnusedResources(logger logr.Logger, cr 
 		&rbacv1.ClusterRoleBindingList{},
 		&rbacv1.ClusterRoleList{},
 		&appsv1.DeploymentList{},
-		&rbacv1.RoleBindingList{},
-		&rbacv1.RoleList{},
 		&corev1.ServiceAccountList{},
 	}
 


### PR DESCRIPTION
We only use clusterroles and clusterrolebindings. This PR removes no needed objects for which operator has no RBAC set.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>