### PR TITLE
Do not requeue new request if provider init failed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	sigs.k8s.io/yaml v1.1.0
 )
 
-replace github.com/ovirt/go-ovirt => github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083
+replace github.com/ovirt/go-ovirt => github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZ
 github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/otiai10/mint v1.2.4 h1:DxYL0itZyPaR5Z9HILdxSoHx+gNs6Yx+neOGS3IVUk0=
 github.com/otiai10/mint v1.2.4/go.mod h1:d+b7n/0R3tdyUYYylALXpWQ/kTN+QobSq/4SRGBkR3M=
-github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083 h1:nW3qTnZ+ytoEZ1JL0EW3+mwjVcfjZ9WB3tSfOHQREgM=
-github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
+github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0 h1:9dTL3/s4HXoLerbZL/N6EVHX62JWXNMIxJ+ephNTTYI=
+github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
@@ -153,6 +153,9 @@ const (
 	// UninitializedProvider represents a failure to initialize the provider
 	UninitializedProvider ValidConditionReason = "UninitializedProvider"
 
+	// UnreachableProvider represents a failure to connect to the provider
+	UnreachableProvider ValidConditionReason = "UnreachableProvider"
+
 	// SourceVmNotFound represents the nonexistence of the source VM
 	SourceVMNotFound ValidConditionReason = "SourceVMNotFound"
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,6 +7,7 @@ type Factory interface {
 
 // VMClient provides interface how source virtual machines should be fetched
 type VMClient interface {
+	TestConnection() error
 	GetVM(id *string, name *string, cluster *string, clusterID *string) (interface{}, error)
 	StopVM(id string) error
 	StartVM(id string) error

--- a/pkg/providers/ovirt/client/ovirt-client.go
+++ b/pkg/providers/ovirt/client/ovirt-client.go
@@ -182,6 +182,11 @@ func (client *richOvirtClient) StartVM(id string) (e error) {
 	return nil
 }
 
+// TestConnection checks the connectivity to oVirt provider
+func (client *richOvirtClient) TestConnection() error {
+	return client.connection.Test()
+}
+
 func (client *richOvirtClient) fetchVM(id *string, name *string, clusterName *string, clusterID *string) (*ovirtsdk.Vm, error) {
 	// Id of the VM specified:
 	if id != nil {

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -149,6 +149,24 @@ func (o *OvirtProvider) Init(secret *corev1.Secret, instance *v2vv1alpha1.Virtua
 	if err != nil {
 		return err
 	}
+	if _, ok := o.ovirtSecretDataMap["apiUrl"]; !ok {
+		return fmt.Errorf("oVirt secret must contain apiUrl attribute")
+	}
+	if len(o.ovirtSecretDataMap["apiUrl"]) == 0 {
+		return fmt.Errorf("oVirt secret apiUrl cannot be empty")
+	}
+	if _, ok := o.ovirtSecretDataMap["username"]; !ok {
+		return fmt.Errorf("oVirt secret must contain username attribute")
+	}
+	if len(o.ovirtSecretDataMap["username"]) == 0 {
+		return fmt.Errorf("oVirt secret username cannot be empty")
+	}
+	if _, ok := o.ovirtSecretDataMap["password"]; !ok {
+		return fmt.Errorf("oVirt secret must contain password attribute")
+	}
+	if len(o.ovirtSecretDataMap["password"]) == 0 {
+		return fmt.Errorf("oVirt secret password cannot be empty")
+	}
 	if _, ok := o.ovirtSecretDataMap["caCert"]; !ok {
 		return fmt.Errorf("oVirt secret must contain caCert attribute")
 	}
@@ -156,6 +174,19 @@ func (o *OvirtProvider) Init(secret *corev1.Secret, instance *v2vv1alpha1.Virtua
 		return fmt.Errorf("oVirt secret caCert cannot be empty")
 	}
 	o.instance = instance
+	return nil
+}
+
+// TestConnection tests the connection to ovirt provider
+func (o *OvirtProvider) TestConnection() error {
+	client, err := o.getClient()
+	if err != nil {
+		return err
+	}
+	err = client.TestConnection()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -18,6 +18,7 @@ const (
 // Provider defines the methods required by source providers for importing a VM
 type Provider interface {
 	Init(*corev1.Secret, *v2vv1alpha1.VirtualMachineImport) error
+	TestConnection() error
 	Close()
 	LoadVM(v2vv1alpha1.VirtualMachineImportSourceSpec) error
 	PrepareResourceMapping(*v2vv1alpha1.ResourceMappingSpec, v2vv1alpha1.VirtualMachineImportSourceSpec)

--- a/tests/matchers/vm-import.go
+++ b/tests/matchers/vm-import.go
@@ -69,7 +69,7 @@ func BeSuccessful(testFramework *framework.Framework) types.GomegaMatcher {
 }
 
 // BeUnsuccessful creates the matcher checking whether Virtual Machine Import is unsuccessful
-func BeUnsuccessful(testFramework *framework.Framework) types.GomegaMatcher {
+func BeUnsuccessful(testFramework *framework.Framework, reason string) types.GomegaMatcher {
 	matcher := hasConditionInStatus{}
 	matcher.timeout = 3 * time.Minute
 	matcher.pollInterval = 5 * time.Second
@@ -77,6 +77,7 @@ func BeUnsuccessful(testFramework *framework.Framework) types.GomegaMatcher {
 
 	matcher.conditionType = v2vv1alpha1.Succeeded
 	matcher.status = corev1.ConditionFalse
+	matcher.reason = reason
 	return &matcher
 }
 

--- a/tests/ovirt/basic_vm_import_negative_test.go
+++ b/tests/ovirt/basic_vm_import_negative_test.go
@@ -85,7 +85,7 @@ var _ = Describe("VM import", func() {
 		created, err := f.VMImportClient.V2vV1alpha1().VirtualMachineImports(namespace).Create(&vmi)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(created).To(HaveValidationFailure(f, string(v2vv1alpha1.SecretNotFound)))
+		Expect(created).To(BeUnsuccessful(f, string(v2vv1alpha1.ValidationFailed)))
 	})
 
 	It("should fail for invalid secret", func() {
@@ -97,7 +97,7 @@ var _ = Describe("VM import", func() {
 		created, err := f.VMImportClient.V2vV1alpha1().VirtualMachineImports(namespace).Create(&vmi)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(created).To(HaveValidationFailure(f, string(v2vv1alpha1.UninitializedProvider)))
+		Expect(created).To(BeUnsuccessful(f, string(v2vv1alpha1.ValidationFailed)))
 	})
 
 	table.DescribeTable("should fail for invalid ", func(vmID string, apiURL string, username string, password string, caCert string) {
@@ -111,7 +111,7 @@ var _ = Describe("VM import", func() {
 		created, err := f.VMImportClient.V2vV1alpha1().VirtualMachineImports(namespace).Create(&vmi)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(created).To(HaveValidationFailure(f, string(v2vv1alpha1.SourceVMNotFound)))
+		Expect(created).To(BeUnsuccessful(f, string(v2vv1alpha1.ValidationFailed)))
 	},
 		table.Entry("oVirt URL", vms.InvalidOVirtUrlVmID, "", ovirt.Username, ovirt.Password, ovirt.CACert),
 		table.Entry("oVirt username", vms.InvalidOVirtUsernameVmID, ovirt.ApiURL, "", ovirt.Password, ovirt.CACert),

--- a/tests/ovirt/multiple_vms_import_test.go
+++ b/tests/ovirt/multiple_vms_import_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Multiple VMs import ", func() {
 			By("Importing second VM")
 			created, err := test.triggerVMImport(vmID, namespace, "vm-no-2", test.secret.Name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(created).To(BeUnsuccessful(f))
+			Expect(created).To(BeUnsuccessful(f, ""))
 		})
 
 		It("should fail importing the same source VM with NIC to different namespace", func() {
@@ -84,7 +84,7 @@ var _ = Describe("Multiple VMs import ", func() {
 			By("Importing second VM")
 			created, err := test.triggerVMImport(vmID, namespace2.Name, "vm-no-2", secret.Name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(created).To(BeUnsuccessful(f))
+			Expect(created).To(BeUnsuccessful(f, ""))
 		})
 
 		It("should create one started VM from two imports of the same NIC-less source VM with same target name to one namespace ", func() {

--- a/vendor/github.com/ovirt/go-ovirt/connection.go
+++ b/vendor/github.com/ovirt/go-ovirt/connection.go
@@ -94,6 +94,9 @@ func (c *Connection) testToken() (int, error) {
 		return 0, err
 	}
 	res, err := c.client.Do(options)
+	if err != nil {
+		return 0, err
+	}
 	defer res.Body.Close()
 
 	return res.StatusCode, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -530,7 +530,7 @@ github.com/operator-framework/operator-sdk/pkg/predicate
 github.com/operator-framework/operator-sdk/pkg/restmapper
 github.com/operator-framework/operator-sdk/pkg/test
 github.com/operator-framework/operator-sdk/version
-# github.com/ovirt/go-ovirt v4.3.4+incompatible => github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083
+# github.com/ovirt/go-ovirt v4.3.4+incompatible => github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0
 github.com/ovirt/go-ovirt
 # github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid


### PR DESCRIPTION
In case of new request, do not reuque the request if the provider
initialization failed due to:
* Missing secret or invalid secret format
* Bad credentials or inability to connect to the provider

In this case, the vmimport will be failed, a condition of type Succeeded
will be created with ValidationFailed reason.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1849527

Signed-off-by: Moti Asayag <masayag@redhat.com>