### PR TITLE
Block import with more than one source network mapped to a pod network

### DIFF
--- a/pkg/providers/ovirt/validation/validators/definitions.go
+++ b/pkg/providers/ovirt/validation/validators/definitions.go
@@ -119,8 +119,10 @@ const (
 	NetworkMappingID = CheckID("network.mapping")
 	// NetworkTypeID defines an ID of a check verifying supported network types
 	NetworkTypeID = CheckID("network.type")
-	// NetworkTargetID defines an ID of a check verifyting existence of target network
+	// NetworkTargetID defines an ID of a check verifying existence of target network
 	NetworkTargetID = CheckID("network.target")
+	// NetworkMultiplePodTargetsID defines an ID of a check verifying that there is not more than one network mapped to a pod network
+	NetworkMultiplePodTargetsID = CheckID("network.pod.multiple")
 	// StorageTargetID defines an ID of a check verifying existence of target storage class
 	StorageTargetID = CheckID("storage.target")
 	// DiskTargetID defines an ID of a check verifying existence of target storage class


### PR DESCRIPTION
KubeVirt does not allow for VMs with multiple interfaces connected to pod networks - this PR introduces proper check at the resource mapping validation stage.
In reference to https://bugzilla.redhat.com/show_bug.cgi?id=1850482.

```release-note
NONE
```

Signed-off-by: Jakub Dzon <jdzon@redhat.com>