### PR TITLE
Recover from oVirt client panic

### DIFF
--- a/pkg/providers/ovirt/client/client_suite_test.go
+++ b/pkg/providers/ovirt/client/client_suite_test.go
@@ -1,0 +1,13 @@
+package ovirtclient_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOvirtClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "oVirt client Suite")
+}

--- a/pkg/providers/ovirt/client/ovirt-client_test.go
+++ b/pkg/providers/ovirt/client/ovirt-client_test.go
@@ -1,0 +1,35 @@
+package ovirtclient
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("oVirt client", func() {
+
+	client := richOvirtClient{
+		// nil connection will cause panic
+		connection: nil,
+	}
+
+	It("should recover from VM retrieval panic", func() {
+		vmID := "any"
+		vm, err := client.GetVM(&vmID, nil, nil, nil)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("panicked"))
+		Expect(vm).To(BeNil())
+	})
+	It("should recover from VM starting panic", func() {
+		err := client.StartVM("any")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("panicked"))
+	})
+	It("should recover from VM stopping panic", func() {
+		err := client.StopVM("any")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("panicked"))
+	})
+})


### PR DESCRIPTION
Ovirtsdk can panic when the payload returned by ovirt is incorrect and this PR allows our oVirt client to handle these panics gracefully by converting them to errors.

```release-note
NONE
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>