### PR TITLE
Allowing for VMs to have Windows-specific UTC-compatible timezones

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,11 @@ const (
 
 var (
 	log = logf.Log.WithName("utils")
+	// windowsUtcCompatibleTimeZones defines Windows-specific UTC-compatible timezones
+	windowsUtcCompatibleTimeZones = map[string]bool{
+		"GMT Standard Time":       true,
+		"Greenwich Standard Time": true,
+	}
 )
 
 // GetMapKeys gets all keys from a map as a slice
@@ -171,6 +176,9 @@ func FormatBytes(bytes int64) (string, error) {
 
 // IsUtcCompatible checks whether given timezone behaves like UTC - has the same offset of 0 and does not observer daylight saving time
 func IsUtcCompatible(timezone string) bool {
+	if windowsUtcCompatibleTimeZones[timezone] {
+		return true
+	}
 	loc, err := time.LoadLocation(timezone)
 	if err != nil {
 		return false

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -91,6 +91,8 @@ var _ = Describe("UTC detection ", func() {
 		table.Entry("Africa/Abidjan", "Africa/Abidjan"),
 		table.Entry("Africa/Conakry", "Africa/Conakry"),
 		table.Entry("America/Danmarkshavn", "America/Danmarkshavn"),
+		table.Entry("GMT Standard Time", "GMT Standard Time"),
+		table.Entry("Greenwich Standard Time", "Greenwich Standard Time"),
 	)
 
 	table.DescribeTable("should detect non UTC-compatible timezone: ", func(timezone string) {

--- a/tests/ovirt/various_vm_configurations_test.go
+++ b/tests/ovirt/various_vm_configurations_test.go
@@ -43,14 +43,17 @@ var _ = Describe("Import", func() {
 	})
 
 	Context("should create started VM configured with", func() {
-		It("UTC-compatible timezone", func() {
+		table.DescribeTable("UTC-compatible timezone", func(timezone string) {
 			vmID := vms.UtcCompatibleTimeZoneVmID
-			test.stub(vmID, "timezone-template.xml", map[string]string{"@TIMEZONE": "Africa/Abidjan"})
+			test.stub(vmID, "timezone-template.xml", map[string]string{"@TIMEZONE": timezone})
 			vm := test.ensureVMIsRunning(vmID)
 
 			spec := vm.Spec.Template.Spec
 			Expect(spec.Domain.Clock.UTC).ToNot(BeNil())
-		})
+		},
+			table.Entry("TzData-compatible: `Africa/Abidjan`", "Africa/Abidjan"),
+			table.Entry("Windows-specific: `GMT Standard Time`", "GMT Standard Time"),
+		)
 
 		table.DescribeTable("BIOS type", func(inBIOSType string, targetBootloader v1.Bootloader) {
 			vmID := vms.BIOSTypeVmIDPrefix + inBIOSType


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1852446

This PR changes source VM timezone validation to allow VMs with UTC-compatible but WIndows-specific timezones to be imported.

```release-notes
NONE
```

Signed-off-by: Jakub Dzon <jdzon@redhat.com>