### PR TITLE
Restore source vm status when import cancelled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/coreos/etcd v3.3.15+incompatible
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -885,13 +886,11 @@ var _ = Describe("Reconcile steps", func() {
 		var (
 			mockMap *mockMapper
 			vmName  types.NamespacedName
-			vmiName types.NamespacedName
 		)
 
 		BeforeEach(func() {
 			mockMap = &mockMapper{}
 			vmName = types.NamespacedName{Name: "test", Namespace: "default"}
-			vmiName = types.NamespacedName{Name: "test", Namespace: "default"}
 			mapDisks = func() (map[string]cdiv1.DataVolume, error) {
 				return map[string]cdiv1.DataVolume{
 					"test": cdiv1.DataVolume{},
@@ -931,7 +930,7 @@ var _ = Describe("Reconcile steps", func() {
 				return map[string]cdiv1.DataVolume{}, nil
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(BeNil())
 		})
@@ -948,7 +947,7 @@ var _ = Describe("Reconcile steps", func() {
 				return fmt.Errorf("Not created")
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -970,7 +969,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(BeNil())
 		})
@@ -984,7 +983,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -1003,7 +1002,7 @@ var _ = Describe("Reconcile steps", func() {
 				return fmt.Errorf("Not modified")
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -1027,7 +1026,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(BeNil())
 		})
@@ -1046,7 +1045,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.importDisks(mock, instance, mockMap, vmName, vmiName)
+			err := reconciler.importDisks(mock, instance, mockMap, vmName)
 
 			Expect(err).To(BeNil())
 		})
@@ -1520,7 +1519,7 @@ func (p *mockProvider) Validate() ([]v2vv1alpha1.VirtualMachineImportCondition, 
 }
 
 // StopVM implements Provider.StopVM
-func (p *mockProvider) StopVM() error {
+func (p *mockProvider) StopVM(cr *v2vv1alpha1.VirtualMachineImport, client rclient.Client) error {
 	return nil
 }
 
@@ -1550,7 +1549,7 @@ func (p *mockProvider) StartVM() error {
 }
 
 // CleanUp implements Provider.CleanUp
-func (p *mockProvider) CleanUp(failure bool) error {
+func (p *mockProvider) CleanUp(failure bool, cr *v2vv1alpha1.VirtualMachineImport, client rclient.Client) error {
 	return cleanUp()
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -24,12 +25,12 @@ type Provider interface {
 	PrepareResourceMapping(*v2vv1alpha1.ResourceMappingSpec, v2vv1alpha1.VirtualMachineImportSourceSpec)
 	Validate() ([]v2vv1alpha1.VirtualMachineImportCondition, error)
 	ValidateDiskStatus(string) (bool, error)
-	StopVM() error
+	StopVM(*v2vv1alpha1.VirtualMachineImport, rclient.Client) error
 	CreateMapper() (Mapper, error)
 	GetVMStatus() (VMStatus, error)
 	GetVMName() (string, error)
 	StartVM() error
-	CleanUp(bool) error
+	CleanUp(bool, *v2vv1alpha1.VirtualMachineImport, rclient.Client) error
 	FindTemplate() (*oapiv1.Template, error)
 	ProcessTemplate(*oapiv1.Template, *string, string) (*kubevirtv1.VirtualMachine, error)
 }


### PR DESCRIPTION
We need to restore original status of source vm when vm import is cancelled. We use restore finalizer to start source vm if needed.

Bug-Url: https://bugzilla.redhat.com/1853351
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>