### PR TITLE
Add metric kubevirt_vmimport

### DIFF
--- a/cluster/operator-install.sh
+++ b/cluster/operator-install.sh
@@ -27,7 +27,7 @@ export VM_IMPORT_CONFIG_STATUS=${VM_IMPORT_CONFIG_STATUS:-''}
 ./cluster/kubectl.sh create -f _out/vm-import-operator/${VERSION}/vmimportconfig_cr.yaml
 # When `kubectl wait` will support `--ignore-not` found parameter this `if` can be removed.
 if [[ "$(./cluster/kubectl.sh get deploy/vm-import-controller -n kubevirt 2>&1)" =~ "not found" ]]; then
-    sleep 2
+    sleep 10
 fi
 ./cluster/kubectl.sh wait deploy/vm-import-controller -n kubevirt --for=condition=Available --timeout=600s
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,16 +21,14 @@ import (
 	"github.com/kubevirt/vm-import-operator/pkg/controller"
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/kubevirt/vm-import-operator/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -40,11 +38,6 @@ import (
 )
 
 // Change below variables to serve metrics on different host or port.
-var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
-)
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
@@ -103,7 +96,7 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress: fmt.Sprintf("%s:%d", metrics.MetricsHost, metrics.MetricsPort),
 	})
 	if err != nil {
 		log.Error(err, "")
@@ -157,30 +150,6 @@ func main() {
 		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
 	}
 
-	// Add to the below struct any other metrics ports you want to expose.
-	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
-	}
-	// Create Service object to expose the metrics port(s).
-	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
-	if err != nil {
-		log.Info("Could not create metrics Service", "error", err.Error())
-	}
-
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-	services := []*v1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, kubevirtNamespace, services)
-	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error", err.Error())
-		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
-		}
-	}
-
 	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
@@ -217,7 +186,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	// To generate metrics in other namespaces, add the values below.
 	ns := []string{operatorNs}
 	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, controllerGVKs, metricsHost, operatorMetricsPort)
+	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, controllerGVKs, metrics.MetricsHost, metrics.OperatorMetricsPort)
 	if err != nil {
 		return err
 	}

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/kubevirt/vm-import-operator/pkg/apis"
 	"github.com/kubevirt/vm-import-operator/pkg/operator/controller"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -69,6 +70,12 @@ func main() {
 	}
 
 	if err := extv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup Scheme for monitoringv1 resources
+	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,7 @@
+# Virtual Machine Import metrics
+
+Virtual Machine Import uses Prometheus for metrics reporting. The metrics can be used for real-time monitoring. Virtual Machine Import does not persist its metrics, if a member restarts, the metrics will be reset.
+
+| Name               | Description                                                     | Type    | Labels                       |
+|--------------------|-----------------------------------------------------------------|---------|------------------------------|
+| kubevirt_vmimport  | The total number of successfull/failed Virtual Machine imports. | Counter | result=<successful>/<failed> |

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/etcd v3.3.15+incompatible
+	github.com/coreos/prometheus-operator v0.35.0
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0
@@ -26,6 +27,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.15.2
 	github.com/ovirt/go-ovirt v4.3.4+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -748,6 +748,7 @@ github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52
 github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52c19a/go.mod h1:ekexcV4O8YMxdQuPb+Xco7MHfVmRIq7Jvj5e6NU7dHI=
 github.com/operator-framework/operator-sdk v0.15.2 h1:VlxI0J+HLmMKs5k53drQ/B1AXhyNj0OaD2BbREt8Hnk=
 github.com/operator-framework/operator-sdk v0.15.2/go.mod h1:RkC5LpluVONa08ORFIIVCYrEr855xG1/NltRL2jQ8qo=
+github.com/operator-framework/operator-sdk v0.18.2 h1:Ts5ckGcJ/Jf+2IXeagsEk87o83bEeA+Z7DwNkyWEBPs=
 github.com/otiai10/copy v1.0.1 h1:gtBjD8aq4nychvRZ2CyJvFWAw0aja+VHazDdruZKGZA=
 github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kubevirt/vm-import-operator/pkg/config"
+	"github.com/kubevirt/vm-import-operator/pkg/metrics"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	pclient "github.com/kubevirt/vm-import-operator/pkg/client"
@@ -955,6 +956,7 @@ func (r *ReconcileVirtualMachineImport) updateProgress(instance *v2vv1alpha1.Vir
 }
 
 func (r *ReconcileVirtualMachineImport) afterSuccess(vmName types.NamespacedName, p provider.Provider, instance *v2vv1alpha1.VirtualMachineImport) error {
+	metrics.ImportCounter.IncSuccessful()
 	vmiName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 	var errs []error
 	err := p.CleanUp(false, instance, r.client)
@@ -975,6 +977,7 @@ func (r *ReconcileVirtualMachineImport) afterSuccess(vmName types.NamespacedName
 
 //TODO: use in proper places
 func (r *ReconcileVirtualMachineImport) afterFailure(p provider.Provider, instance *v2vv1alpha1.VirtualMachineImport) error {
+	metrics.ImportCounter.IncFailed()
 	vmiName := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 	var errs []error
 	err := p.CleanUp(true, instance, r.client)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// MetricsHost host that servers the metrics
+	MetricsHost = "0.0.0.0"
+	// MetricsPort port where metrics are served
+	MetricsPort int32 = 8383
+	// OperatorMetricsPort port where operator metrics are served
+	OperatorMetricsPort int32 = 8686
+)
+
+var (
+	// counter vector which count the number of vm imports done
+	importCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubevirt_vmimport_counter",
+			Help: "Count of virtual machine import done",
+		},
+		[]string{"result"},
+	)
+	// ImportCounter counter which hold number of vm imports done
+	ImportCounter = importCounter{importCounterVec}
+)
+
+func init() {
+	metrics.Registry.MustRegister(importCounterVec)
+}
+
+// ImportCounter hold the importCounter counter vector
+type importCounter struct {
+	importCounterVec *prometheus.CounterVec
+}
+
+// IncFailed increment failed label
+func (ic *importCounter) IncFailed() {
+	ic.importCounterVec.With(prometheus.Labels{"result": "failed"}).Inc()
+}
+
+// IncSuccessful increment successfull label
+func (ic *importCounter) IncSuccessful() {
+	ic.importCounterVec.With(prometheus.Labels{"result": "successful"}).Inc()
+}

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -14,6 +14,7 @@ import (
 
 	conditions "github.com/openshift/custom-resource-status/conditions/v1"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	vmimportv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	resources "github.com/kubevirt/vm-import-operator/pkg/operator/resources/operator"
 	appsv1 "k8s.io/api/apps/v1"
@@ -55,6 +56,7 @@ var (
 func init() {
 	vmimportv1alpha1.AddToScheme(scheme.Scheme)
 	extv1beta1.AddToScheme(scheme.Scheme)
+	monitoringv1.AddToScheme(scheme.Scheme)
 }
 
 type modifyResource func(toModify runtime.Object) (runtime.Object, runtime.Object, error)

--- a/templates/vm-import-operator/VERSION/operator.yaml.in
+++ b/templates/vm-import-operator/VERSION/operator.yaml.in
@@ -107,6 +107,7 @@ rules:
   - configmaps
   - secrets
   - serviceaccounts
+  - services
   verbs:
   - '*'
 - apiGroups:
@@ -135,6 +136,12 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
   verbs:
   - '*'
 ---
@@ -193,3 +200,5 @@ spec:
               value: {{CONTAINER_PREFIX}}/{{CONTROLLER_IMAGE}}:{{IMAGE_TAG}}
             - name: PULL_POLICY
               value: {{IMAGE_PULL_POLICY}}
+            - name: MONITORING_NAMESPACE
+              value: openshift-monitoring


### PR DESCRIPTION
Currently tested on `kubernetes` with `kube-prometheus`, the only hack which must be done to make it working is to add `list`, `get` and `watch` verb to resource `services`, `pods` and `endpoints` for `prometheus-k8s` `serviceaccount`. like this:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: prometheus-k8s
rules:
- apiGroups:
  - ""
  resources:
  - nodes/metrics
  - services
  - pods
  - endpoints
  verbs:
  - get
  - list
  - watch
- nonResourceURLs:
  - /metrics
  verbs:
  - get
```

Ready for initial review.

Signed-off-by: Ondra Machacek <omachace@redhat.com>