### PR TITLE
Fix func tests for kubevirt v0.30.4

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -16,7 +16,7 @@ function install_cdi {
 }
 
 function install_kubevirt {
-    export KUBEVIRT_VER="v0.30.3"
+    export KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VER}/kubevirt-operator.yaml
     ./cluster/kubectl.sh create configmap -n kubevirt kubevirt-config --from-literal=feature-gates=DataVolumes,ImportWithoutTemplate
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VER}/kubevirt-cr.yaml


### PR DESCRIPTION
Since kubevirt v0.30.4 secure boot is enabled by default for the EFI
bootloader, so we need to enable SMM, for EFI bootloaders.

Signed-off-by: Ondra Machacek <omachace@redhat.com>