### PR TITLE
Fix CDI negative disk size test

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -9,7 +9,7 @@ function debug {
 }
 
 function install_cdi {
-    export VERSION="v1.18.2"
+    export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
     ./cluster/kubectl.sh wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=1200s || debug cdi

--- a/tests/ovirt/basic_vm_import_negative_test.go
+++ b/tests/ovirt/basic_vm_import_negative_test.go
@@ -75,7 +75,7 @@ var _ = Describe("VM import", func() {
 		}
 	},
 		table.Entry("invalid disk image", "4096"),
-		table.Entry("invalid disk size", "0"),
+		table.Entry("invalid disk size", "1"),
 	)
 
 	It("should fail for missing secret", func() {


### PR DESCRIPTION
Since CDI v1.20.0 CDI block the disk with size `0`, and don't continue with the import, and don't report any failure, so this PR changes disk size to 1, which is invalid as well, but fails the imports, as test expects.

```
{"level":"error","ts":1594834281.3860211,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"datavolume-controller","request":"vm-import-e2e-tests-basic-vm-import-negative-dkrqf/target-vm-attachment-1","error":"PersistentVolumeClaim \"target-vm-attachment-1\" is invalid: spec.resources[storage]: Invalid value: \"0\": must be greater than zero","stacktrace":"kubevirt.io/containerized-data-importer/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\tvendor/github.com/go-logr/zapr/zapr.go:128\nkubevirt.io/containerized-data-importer/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tvendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\nkubevirt.io/containerized-data-importer/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tvendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nkubevirt.io/containerized-data-importer/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tvendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nkubevirt.io/containerized-data-importer/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nkubevirt.io/containerized-data-importer/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nkubevirt.io/containerized-data-importer/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\tvendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

Signed-off-by: Ondra Machacek <omachace@redhat.com>