### PR TITLE
Target VM name length-related changes

### DIFF
--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -140,10 +140,10 @@
 ## Running tests
 
 ### With kubevirtci
-Tests can be run against kubevirtci-based local k8s cluster. To run them, execute 
+Tests can be run against kubevirtci-based local k8s cluster. To run them, execute
 ```bash
 automation/test.sh
-``` 
+```
 
 ### With external k8s cluster
 Test suite can be run against existing, external k8s cluster. To do it, execute:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/coreos/etcd v3.3.15+incompatible
 	github.com/coreos/prometheus-operator v0.35.0
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/go.sum
+++ b/go.sum
@@ -748,7 +748,6 @@ github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52
 github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52c19a/go.mod h1:ekexcV4O8YMxdQuPb+Xco7MHfVmRIq7Jvj5e6NU7dHI=
 github.com/operator-framework/operator-sdk v0.15.2 h1:VlxI0J+HLmMKs5k53drQ/B1AXhyNj0OaD2BbREt8Hnk=
 github.com/operator-framework/operator-sdk v0.15.2/go.mod h1:RkC5LpluVONa08ORFIIVCYrEr855xG1/NltRL2jQ8qo=
-github.com/operator-framework/operator-sdk v0.18.2 h1:Ts5ckGcJ/Jf+2IXeagsEk87o83bEeA+Z7DwNkyWEBPs=
 github.com/otiai10/copy v1.0.1 h1:gtBjD8aq4nychvRZ2CyJvFWAw0aja+VHazDdruZKGZA=
 github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -31,7 +31,7 @@ func NewManager(client client.Client) Manager {
 func (m *Manager) FindFor(vmiCrName types.NamespacedName) (*corev1.ConfigMap, error) {
 	mapList := corev1.ConfigMapList{}
 	labels := client.MatchingLabels{
-		vmiNameLabel: utils.MakeLabelFrom(vmiCrName.Name),
+		vmiNameLabel: utils.EnsureLabelValueLength(vmiCrName.Name),
 	}
 
 	err := m.client.List(context.TODO(), &mapList, labels, client.InNamespace(vmiCrName.Namespace))
@@ -58,7 +58,7 @@ func (m *Manager) CreateFor(configMap *corev1.ConfigMap, vmiCrName types.Namespa
 	if configMap.Labels == nil {
 		configMap.Labels = make(map[string]string)
 	}
-	configMap.Labels[vmiNameLabel] = utils.MakeLabelFrom(vmiCrName.Name)
+	configMap.Labels[vmiNameLabel] = utils.EnsureLabelValueLength(vmiCrName.Name)
 
 	return m.client.Create(context.TODO(), configMap)
 }

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -765,6 +765,7 @@ func (r *ReconcileVirtualMachineImport) createDataVolume(provider provider.Provi
 	// Update VM spec with imported disks:
 	err = r.updateVMSpecDataVolumes(mapper, types.NamespacedName{Namespace: vmName.Namespace, Name: vmName.Name}, dv)
 	if err != nil {
+		log.Error(err, "Cannot update VMSpec Data Volumes")
 		return err
 	}
 

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/validation"
+
 	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	vmimportmetrics "github.com/kubevirt/vm-import-operator/pkg/metrics"
@@ -547,6 +549,7 @@ func CreateVMImportConfig() *extv1beta1.CustomResourceDefinition {
 
 // CreateVMImport creates the VM Import CRD
 func CreateVMImport() *extv1beta1.CustomResourceDefinition {
+	maxTargetVMName := int64(validation.LabelValueMaxLength)
 	return &extv1beta1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apiextensions.k8s.io/v1beta1",
@@ -806,7 +809,8 @@ the disk alias on ovirt DiskMappings is respected only when provided in context 
 									Type: "boolean",
 								},
 								"targetVmName": {
-									Type: "string",
+									Type:      "string",
+									MaxLength: &maxTargetVMName,
 								},
 							},
 							Required: []string{"providerCredentialsSecret", "source"},

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -398,7 +398,7 @@ func (o *OvirtMapper) ResolveVMName(targetVMName *string) *string {
 		return nil
 	}
 	// VM name is put in label values and has to be shorter than regular k8s name
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1857165
+	// https://bugzilla.redhat.com/1857165
 	name := utils.EnsureLabelValueLength(*vmNameBase)
 	return &name
 }

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -186,8 +186,10 @@ func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMach
 // MapDisk map VM disk
 func (o *OvirtMapper) MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVolume) {
 	// Map volume
+	name := fmt.Sprintf("dv-%v", dv.Name)
+	name = utils.EnsureLabelValueLength(name)
 	volume := kubevirtv1.Volume{
-		Name: fmt.Sprintf("dv-%v", dv.Name),
+		Name: name,
 		VolumeSource: kubevirtv1.VolumeSource{
 			DataVolume: &kubevirtv1.DataVolumeSource{
 				Name: dv.Name,
@@ -200,7 +202,7 @@ func (o *OvirtMapper) MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVo
 	diskAttachment := getDiskAttachmentByID(dv.Name, diskAttachments, vmSpec.ObjectMeta.Name)
 	iface, _ := diskAttachment.Interface()
 	disk := kubevirtv1.Disk{
-		Name: fmt.Sprintf("dv-%v", dv.Name),
+		Name: name,
 		DiskDevice: kubevirtv1.DiskDevice{
 			Disk: &kubevirtv1.DiskTarget{
 				Bus: o.mapDiskInterface(iface),
@@ -391,6 +393,17 @@ func (o *OvirtMapper) mapNetworkType(mapping v2vv1alpha1.ResourceMappingItem, ku
 
 // ResolveVMName resolves the target VM name
 func (o *OvirtMapper) ResolveVMName(targetVMName *string) *string {
+	vmNameBase := o.resolveVMNameBase(targetVMName)
+	if vmNameBase == nil {
+		return nil
+	}
+	// VM name is put in label values and has to be shorter than regular k8s name
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1857165
+	name := utils.EnsureLabelValueLength(*vmNameBase)
+	return &name
+}
+
+func (o *OvirtMapper) resolveVMNameBase(targetVMName *string) *string {
 	if targetVMName != nil {
 		return targetVMName
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -31,7 +31,7 @@ func NewManager(client client.Client) Manager {
 func (m *Manager) FindFor(vmiCrName types.NamespacedName) (*corev1.Secret, error) {
 	secretList := corev1.SecretList{}
 	labels := client.MatchingLabels{
-		vmiNameLabel: utils.MakeLabelFrom(vmiCrName.Name),
+		vmiNameLabel: utils.EnsureLabelValueLength(vmiCrName.Name),
 	}
 
 	err := m.client.List(context.TODO(), &secretList, labels, client.InNamespace(vmiCrName.Namespace))
@@ -58,7 +58,7 @@ func (m *Manager) CreateFor(secret *corev1.Secret, vmiCrName types.NamespacedNam
 	if secret.Labels == nil {
 		secret.Labels = make(map[string]string)
 	}
-	secret.Labels[vmiNameLabel] = utils.MakeLabelFrom(vmiCrName.Name)
+	secret.Labels[vmiNameLabel] = utils.EnsureLabelValueLength(vmiCrName.Name)
 
 	return m.client.Create(context.TODO(), secret)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -120,7 +120,7 @@ func WithMessage(message string, newMessage string) string {
 	return fmt.Sprintf("%s, %s", message, newMessage)
 }
 
-// EnsureLabelValueLength shortens given value to the maximal label value length of 63 characters
+// EnsureLabelValueLength shortens given value to the maximum label value length of 63 characters
 func EnsureLabelValueLength(value string) string {
 	n := len(value)
 	if n > k8svalidation.LabelValueMaxLength {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,9 +18,6 @@ import (
 )
 
 const (
-	// MaxLabelValueLength specifies max length of k8s label value
-	MaxLabelValueLength = 63
-
 	// RestoreVMStateFinalizer defines restore source vm finalizer
 	RestoreVMStateFinalizer = "vmimport.v2v.kubevirt.io/restore-state"
 )
@@ -123,17 +120,16 @@ func WithMessage(message string, newMessage string) string {
 	return fmt.Sprintf("%s, %s", message, newMessage)
 }
 
-// MakeLabelFrom creates label value from given CR name
-func MakeLabelFrom(name string) string {
-	n := len(name)
-	if n > MaxLabelValueLength {
-		log.Info("Label value will be shortened to 63 characters", "CR name", name)
+// EnsureLabelValueLength shortens given value to the maximal label value length of 63 characters
+func EnsureLabelValueLength(value string) string {
+	n := len(value)
+	if n > k8svalidation.LabelValueMaxLength {
 		suffix := strconv.Itoa(n)
 		suffixLen := len(suffix)
-		maxNameLen := MaxLabelValueLength - suffixLen - 1
-		return fmt.Sprintf("%s_%s", name[:maxNameLen], suffix)
+		maxNameLen := k8svalidation.LabelValueMaxLength - suffixLen - 1
+		return fmt.Sprintf("%s-%s", value[:maxNameLen], suffix)
 	}
-	return name
+	return value
 }
 
 // AppendMap adds a map

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -161,7 +161,7 @@ var _ = Describe("UTC Offset string parsing", func() {
 
 var _ = Describe("Label generation", func() {
 	table.DescribeTable("should generate labels being unmodified names", func(name string) {
-		label := utils.MakeLabelFrom(name)
+		label := utils.EnsureLabelValueLength(name)
 
 		Expect(label).To(BeEquivalentTo(name))
 	},
@@ -174,13 +174,13 @@ var _ = Describe("Label generation", func() {
 	)
 
 	table.DescribeTable("should generate labels being shortened names", func(name string, expectedName string) {
-		label := utils.MakeLabelFrom(name)
+		label := utils.EnsureLabelValueLength(name)
 
 		Expect(label).To(BeEquivalentTo(expectedName))
 	},
-		table.Entry("slightly longer", createStringOfLength(64), createStringOfLength(60)+"_64"),
-		table.Entry("three digits long", createStringOfLength(128), createStringOfLength(59)+"_128"),
-		table.Entry("max resource name", createStringOfLength(253), createStringOfLength(59)+"_253"),
+		table.Entry("slightly longer", createStringOfLength(64), createStringOfLength(60)+"-64"),
+		table.Entry("three digits long", createStringOfLength(128), createStringOfLength(59)+"-128"),
+		table.Entry("max resource name", createStringOfLength(253), createStringOfLength(59)+"-253"),
 	)
 })
 

--- a/tests/ovirt/basic_vm_import_negative_test.go
+++ b/tests/ovirt/basic_vm_import_negative_test.go
@@ -201,6 +201,18 @@ var _ = Describe("VM import", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(created).To(HaveTemplateMatchingFailure(f))
 	})
+
+	It("should fail when targetVMName is too long", func() {
+		vmID := vms.BasicVmID
+		vmName := strings.Repeat("x", 64)
+		vmi := utils.VirtualMachineImportCrWithName(vmID, namespace, secret.Name, f.NsPrefix, true, vmName)
+		test.prepareVm(vmID)
+
+		_, err := f.VMImportClient.V2vV1alpha1().VirtualMachineImports(namespace).Create(&vmi)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.targetVmName in body should be at most 63 chars long"))
+	})
 })
 
 func (t *basicVMImportNegativeTest) createInvalidSecret() *corev1.Secret {

--- a/tests/ovirt/cancel_vm_import_test.go
+++ b/tests/ovirt/cancel_vm_import_test.go
@@ -121,7 +121,7 @@ var _ = Describe("VM import cancellation ", func() {
 
 func getTemporaryConfigMap(f *framework.Framework, namespace string, vmiName string) (*corev1.ConfigMap, error) {
 	listOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("vmimport.v2v.kubevirt.io/vmi-name=%s", oputils.MakeLabelFrom(vmiName)),
+		LabelSelector: fmt.Sprintf("vmimport.v2v.kubevirt.io/vmi-name=%s", oputils.EnsureLabelValueLength(vmiName)),
 	}
 	list, err := f.K8sClient.CoreV1().ConfigMaps(namespace).List(listOptions)
 	if err != nil {
@@ -135,7 +135,7 @@ func getTemporaryConfigMap(f *framework.Framework, namespace string, vmiName str
 
 func getTemporarySecret(f *framework.Framework, namespace string, vmiName string) (*corev1.Secret, error) {
 	listOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("vmimport.v2v.kubevirt.io/vmi-name=%s", oputils.MakeLabelFrom(vmiName)),
+		LabelSelector: fmt.Sprintf("vmimport.v2v.kubevirt.io/vmi-name=%s", oputils.EnsureLabelValueLength(vmiName)),
 	}
 	list, err := f.K8sClient.CoreV1().Secrets(namespace).List(listOptions)
 	if err != nil {

--- a/tests/ovirt/various_vm_configurations_test.go
+++ b/tests/ovirt/various_vm_configurations_test.go
@@ -189,6 +189,25 @@ var _ = Describe("Import", func() {
 
 		test.ensureVMIsRunning(vmID)
 	})
+
+	table.DescribeTable("should create started VM for targetVMName with length", func(nameLength int) {
+		vmID := vms.BasicVmID
+		test.stub(vmID, "basic-vm.xml", map[string]string{})
+
+		vm := test.ensureVMIsRunningOnStorageWithVMName(vmID, nil, strings.Repeat("x", nameLength))
+
+		disks := vm.Spec.Template.Spec.Domain.Devices.Disks
+		Expect(disks).To(HaveLen(1))
+		volumes := vm.Spec.Template.Spec.Volumes
+		Expect(volumes).To(HaveLen(1))
+
+		Expect(volumes[0].Name).To(BeEquivalentTo(disks[0].Name))
+	},
+		table.Entry("47 - disk and volume names would be at the limit: dv-<name>-attachment-1", 47),
+		table.Entry("63 - label limit", 63),
+		table.Entry("64 - slightly above label limit", 64),
+		table.Entry("128 - way above label limit", 64),
+	)
 })
 
 func cleanUpConfigMap(f *fwk.Framework) {
@@ -208,9 +227,13 @@ func (t *variousVMConfigurationsTest) ensureVMIsRunning(vmID string) *v1.Virtual
 }
 
 func (t *variousVMConfigurationsTest) ensureVMIsRunningOnStorage(vmID string, storageMappings *[]v2vv1alpha1.ResourceMappingItem) *v1.VirtualMachine {
+	return t.ensureVMIsRunningOnStorageWithVMName(vmID, storageMappings, "target-vm")
+}
+
+func (t *variousVMConfigurationsTest) ensureVMIsRunningOnStorageWithVMName(vmID string, storageMappings *[]v2vv1alpha1.ResourceMappingItem, targetVMName string) *v1.VirtualMachine {
 	f := t.framework
 	namespace := t.framework.Namespace.Name
-	vmi := utils.VirtualMachineImportCr(vmID, namespace, t.secret.Name, f.NsPrefix, true)
+	vmi := utils.VirtualMachineImportCrWithName(vmID, namespace, t.secret.Name, f.NsPrefix, true, targetVMName)
 	vmi.Spec.Source.Ovirt.Mappings = &v2vv1alpha1.OvirtMappings{
 		NetworkMappings: &[]v2vv1alpha1.ResourceMappingItem{
 			{Source: v2vv1alpha1.Source{ID: &vms.VNicProfile1ID}, Type: &tests.PodType},

--- a/tests/ovirt/various_vm_configurations_test.go
+++ b/tests/ovirt/various_vm_configurations_test.go
@@ -205,8 +205,6 @@ var _ = Describe("Import", func() {
 	},
 		table.Entry("47 - disk and volume names would be at the limit: dv-<name>-attachment-1", 47),
 		table.Entry("63 - label limit", 63),
-		table.Entry("64 - slightly above label limit", 64),
-		table.Entry("128 - way above label limit", 64),
 	)
 })
 


### PR DESCRIPTION
Re: https://bugzilla.redhat.com/show_bug.cgi?id=1857165

Series of related fixes:
- Failing import that encounters problems with DV creation (including adding volume and disk to a VM);
- Rejecting (on API level) CRs with targetVMName longer than 63 characters;
- Shortening target VM name to 63 characters.;
- Shortening VM's disk and volume names to 63 characters.;

```release-note
NONE
```

Signed-off-by: Jakub Dzon <jdzon@redhat.com>