### PR TITLE
Add reason of timeout error to tests

### DIFF
--- a/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -225,6 +227,13 @@ type VirtualMachineImportCondition struct {
 	// The last time the condition transit from one status to another
 	// +optional
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+}
+
+func (cond VirtualMachineImportCondition) String() string {
+	return fmt.Sprintf(
+		"VirtualMachineImportCondition{type: %v, status: %v, reason: %v, message: %v}",
+		cond.Type, cond.Status, *cond.Reason, *cond.Message,
+	)
 }
 
 // DataVolumeItem defines the details of a data volume created by the VM import process

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -109,6 +109,7 @@ func init() {
 func NewFrameworkOrDie(prefix string) *Framework {
 	f, err := NewFramework(prefix)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err)
 		ginkgo.Fail(fmt.Sprintf("failed to create test framework: %v", err))
 	}
 	return f

--- a/tests/framework/vm-import.go
+++ b/tests/framework/vm-import.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"fmt"
 	"time"
 
 	v2vv1alpha1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
@@ -48,6 +49,18 @@ func (f *Framework) WaitForVMImportConditionInStatus(pollInterval time.Duration,
 		}
 		return true, nil
 	})
+	if pollErr == wait.ErrWaitTimeout {
+		retrieved, err := f.VMImportClient.V2vV1alpha1().VirtualMachineImports(namespace).Get(vmiName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf(
+			"Timed out waiting for the condition type 'VirtualMachineImportCondition(type: %v, reason: %v, status: %v)', got instead '%v'",
+			conditionType, reason, status, retrieved.Status.Conditions,
+		)
+	}
+
 	return pollErr
 }
 


### PR DESCRIPTION
The error will now look like:
```
STEP: Building a "basic-vm-import-negative" namespace api object
INFO: Created new namespace "vm-import-e2e-tests-basic-vm-import-negative-47ks6"
STEP: Destroying namespace "vm-import-e2e-tests-basic-vm-import-negative-47ks6" for this suite.

------------------------------
• Failure [306.155 seconds]
VM import
/Users/omachace/go/src/github.com/kubevirt/vm-import-operator/tests/ovirt/basic_vm_import_negative_test.go:33
  should fail import with
  /Users/omachace/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
    invalid disk size [It]
    /Users/omachace/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Timed out waiting for the condition type 'Succeeded(reason=DataVolumeCreationFailed, status=False)', got instead '[]v1alpha1.VirtualMachineImportCondition{v1alpha1.VirtualMachineImportCondition{Type:"Valid", Status:"True", Reason:(*string)(0xc000728c30), Message:(*string)(0xc000728c20), LastHeartbeatTime:(*v1.Time)(0xc000a61de0), LastTransitionTime:(*v1.Time)(0xc000a61e40)}, v1alpha1.VirtualMachineImportCondition{Type:"MappingRulesVerified", Status:"True", Reason:(*string)(0xc000728c90), Message:(*string)(0xc000728c80), LastHeartbeatTime:(*v1.Time)(0xc000a61ea0), LastTransitionTime:(*v1.Time)(0xc000a61f00)}, v1alpha1.VirtualMachineImportCondition{Type:"Processing", Status:"True", Reason:(*string)(0xc000728cf0), Message:(*string)(0xc000728ce0), LastHeartbeatTime:(*v1.Time)(0xc000a61f60), LastTransitionTime:(*v1.Time)(0xc000a61fc0)}}'

    /Users/omachace/go/src/github.com/kubevirt/vm-import-operator/tests/ovirt/basic_vm_import_negative_test.go:60
```

Fixes: https://github.com/kubevirt/vm-import-operator/issues/332

Signed-off-by: Ondra Machacek <omachace@redhat.com>