### PR TITLE
Using JSON Patch for updating conditions

### DIFF
--- a/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1alpha1/virtualmachineimport_types.go
@@ -90,7 +90,7 @@ type VirtualMachineImportStatus struct {
 	Conditions []VirtualMachineImportCondition `json:"conditions"`
 
 	// +optional
-	DataVolumes []DataVolumeItem `json:"dataVolumes"`
+	DataVolumes []DataVolumeItem `json:"dataVolumes,omitempty"`
 }
 
 // VirtualMachineImportConditionType defines the condition of VM import


### PR DESCRIPTION
Fixes #322 by using VM Import CRD retrieved directly from the cluster as a base for changes and status update for persisting the changes.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>