### PR TITLE
Add Valid condition warning when default storage class is about to be used

### DIFF
--- a/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
@@ -163,6 +163,9 @@ const (
 
 	// IncompleteMappingRules represents the inability to prepare the mapping rules
 	IncompleteMappingRules ValidConditionReason = "IncompleteMappingRules"
+
+	// ValidationReportedWarnings represents the existence of warnings related to resource mapping validation
+	ValidationReportedWarnings ValidConditionReason = "ValidationReportedWarnings"
 )
 
 // MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import

--- a/pkg/providers/ovirt/validation/validators/definitions.go
+++ b/pkg/providers/ovirt/validation/validators/definitions.go
@@ -127,6 +127,8 @@ const (
 	StorageTargetID = CheckID("storage.target")
 	// DiskTargetID defines an ID of a check verifying existence of target storage class
 	DiskTargetID = CheckID("disk.target")
+	// StorageTargetDefaultClass defines an ID of a check verifying whether the default storage class is used in mapping
+	StorageTargetDefaultClass = CheckID("storage.target.default")
 )
 
 // CheckID identifies validation check for Virtual Machine Import

--- a/pkg/providers/ovirt/validation/validators/storage-mapping-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/storage-mapping-validator_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Validating Storage mapping", func() {
 			return &sc, nil
 		}
 	})
-	table.DescribeTable("should ignore missing mapping for: ", func(sd *ovirtsdk.StorageDomain, domainName *string, domainID *string) {
+	table.DescribeTable("should ignore missing mapping (with warning) for: ", func(sd *ovirtsdk.StorageDomain, domainName *string, domainID *string) {
 		da := createDiskAttachment(sd)
 		das := []*ovirtsdk.DiskAttachment{
 			da,
@@ -60,7 +60,8 @@ var _ = Describe("Validating Storage mapping", func() {
 
 		failures := validator.ValidateStorageMapping(das, &mapping, nil)
 
-		Expect(failures).To(BeEmpty())
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetDefaultClass))
 	},
 		table.Entry("No mapping", createDomain(&domainName, &domainID), nil, nil),
 		table.Entry("ID mismatch", createDomain(&domainName, &domainID), nil, &wrongDomainID),
@@ -113,7 +114,8 @@ var _ = Describe("Validating Storage mapping", func() {
 
 		failures := validator.ValidateStorageMapping(das, &mapping, nil)
 
-		Expect(failures).To(BeEmpty())
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetDefaultClass))
 	})
 	It("should reject mapping for storage class retrieval error", func() {
 		sd := createDomain(&domainName, &domainID)
@@ -186,7 +188,7 @@ var _ = Describe("Validating Storage mapping", func() {
 		Expect(failures[1].Message).To(ContainSubstring(otherDomainID))
 		Expect(failures[1].Message).To(ContainSubstring(otherDomainName))
 	})
-	It("should accept nil mapping", func() {
+	It("should accept nil mapping (with warning)", func() {
 		sd := createDomain(&domainName, &domainID)
 		da := createDiskAttachment(sd)
 		das := []*ovirtsdk.DiskAttachment{
@@ -195,7 +197,8 @@ var _ = Describe("Validating Storage mapping", func() {
 
 		failures := validator.ValidateStorageMapping(das, nil, nil)
 
-		Expect(failures).To(BeEmpty())
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetDefaultClass))
 	})
 })
 
@@ -211,7 +214,7 @@ var _ = Describe("Validating Disk mapping", func() {
 			return &sc, nil
 		}
 	})
-	table.DescribeTable("should accept missing mapping for: ", func(diskName *string, diskID *string) {
+	table.DescribeTable("should accept missing mapping (with warning) for: ", func(diskName *string, diskID *string) {
 		da := createDiskAttachment(createDomain(&domainName, &domainID))
 		das := []*ovirtsdk.DiskAttachment{
 			da,
@@ -231,7 +234,8 @@ var _ = Describe("Validating Disk mapping", func() {
 
 		failures := validator.ValidateStorageMapping(das, nil, &diskMapping)
 
-		Expect(failures).To(BeEmpty())
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetDefaultClass))
 	},
 		table.Entry("No mapping", nil, nil),
 		table.Entry("ID mismatch", nil, &wrongDiskID),
@@ -284,7 +288,8 @@ var _ = Describe("Validating Disk mapping", func() {
 
 		failures := validator.ValidateStorageMapping(das, nil, &diskMapping)
 
-		Expect(failures).To(BeEmpty())
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetDefaultClass))
 	})
 	It("should reject disk mapping for storage class retrieval error", func() {
 		da := createDiskAttachment(createDomain(&domainName, &domainID))
@@ -355,7 +360,7 @@ var _ = Describe("Validating Disk mapping", func() {
 		Expect(failures[1].Message).To(ContainSubstring(otherDiskID))
 		Expect(failures[1].Message).To(ContainSubstring(otherDiskName))
 	})
-	It("should accept nil mapping", func() {
+	It("should accept nil mapping (with warning)", func() {
 		da := createDiskAttachment(createDomain(&domainName, &domainID))
 		das := []*ovirtsdk.DiskAttachment{
 			da,
@@ -363,7 +368,8 @@ var _ = Describe("Validating Disk mapping", func() {
 
 		failures := validator.ValidateStorageMapping(das, &[]v2vv1.StorageResourceMappingItem{}, nil)
 
-		Expect(failures).To(BeEmpty())
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.StorageTargetDefaultClass))
 	})
 	It("should accept mapping for storage class and disk mapping", func() {
 		sd := createDomain(&domainName, &domainID)

--- a/tests/ovirt/basic_vm_import_test.go
+++ b/tests/ovirt/basic_vm_import_test.go
@@ -3,6 +3,8 @@ package ovirt_test
 import (
 	"time"
 
+	"github.com/kubevirt/vm-import-operator/pkg/conditions"
+
 	v2vv1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	"github.com/onsi/ginkgo/extensions/table"
 
@@ -55,6 +57,10 @@ var _ = Describe("Basic VM import ", func() {
 			retrieved, _ := f.VMImportClient.V2vV1beta1().VirtualMachineImports(namespace).Get(created.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			validCondition := conditions.FindConditionOfType(retrieved.Status.Conditions, v2vv1.Valid)
+			Expect(validCondition.Status).To(BeEquivalentTo(corev1.ConditionTrue))
+			Expect(*validCondition.Reason).To(BeEquivalentTo(v2vv1.ValidationReportedWarnings))
+
 			vmBlueprint := v1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: retrieved.Status.TargetVMName, Namespace: namespace}}
 			Expect(vmBlueprint).NotTo(BeRunning(f).Timeout(2 * time.Minute))
 
@@ -72,6 +78,10 @@ var _ = Describe("Basic VM import ", func() {
 
 			retrieved, _ := f.VMImportClient.V2vV1beta1().VirtualMachineImports(namespace).Get(created.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
+
+			validCondition := conditions.FindConditionOfType(retrieved.Status.Conditions, v2vv1.Valid)
+			Expect(validCondition.Status).To(BeEquivalentTo(corev1.ConditionTrue))
+			Expect(*validCondition.Reason).To(BeEquivalentTo(v2vv1.ValidationReportedWarnings))
 
 			vmBlueprint := v1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: retrieved.Status.TargetVMName, Namespace: namespace}}
 			Expect(vmBlueprint).To(BeRunning(f))


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1853403

When the default storage class is going to be used for a disk, `Valid` condition will look like the one below:
```yaml
    - lastHeartbeatTime: "2020-07-29T12:08:45Z"
      lastTransitionTime: "2020-07-29T12:08:45Z"
      message: Default storage class will be used for disk disk-1(disk-1)
      reason: ValidationReportedWarnings
      status: "True"
      type: Valid
```
```release-note
NONE
```