### PR TITLE
Allow to import vms using i440fx bios

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -60,7 +60,7 @@ ID | Predicate | Action
 ID | Predicate | Action
 --- | --- | ---
 1 | VM.bios.boot_menu.enabled == true | Log
-2 | VM.bios.type not matching ClusterConfig.EmulatedMachines (i.e. i440fx_sea_bios by default) | Block
+2 | VM.bios.type not matching ClusterConfig.EmulatedMachines | Block
 3 | VM.bios.type == q35_secure_boot | Warn
 4 | VM.cpu.architecture == s390x (default) or anything that does not match ClusterConfig.EmulatedMachines | Block
 5 | VM.cpu.cpu_tune setting is other than 1 vCPU- 1 pCPU. Allowed config example: ```<cputune><vcpupin vcpu="0" cpuset="0"/><vcpupin vcpu="1" cpuset="1"/><vcpupin vcpu="2" cpuset="2"/><vcpupin vcpu="3" cpuset="3"/></cputune>``` | Warn

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -48,9 +48,10 @@ var (
 
 // BiosTypeMapping defines mapping of BIOS types between oVirt and kubevirt domains
 var BiosTypeMapping = map[string]*kubevirtv1.Bootloader{
-	"q35_sea_bios":    &kubevirtv1.Bootloader{BIOS: &kubevirtv1.BIOS{}},
-	"q35_secure_boot": &kubevirtv1.Bootloader{BIOS: &kubevirtv1.BIOS{}},
-	"q35_ovmf":        &kubevirtv1.Bootloader{EFI: &kubevirtv1.EFI{}},
+	"q35_sea_bios":    {BIOS: &kubevirtv1.BIOS{}},
+	"q35_secure_boot": {BIOS: &kubevirtv1.BIOS{}},
+	"q35_ovmf":        {EFI: &kubevirtv1.EFI{}},
+	"i440fx_sea_bios": {BIOS: &kubevirtv1.BIOS{}},
 }
 
 var archMapping = map[string]string{

--- a/pkg/providers/ovirt/validation/validators/vm-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Validating VM", func() {
 		Expect(failures).To(HaveLen(1))
 		Expect(failures[0].ID).To(Equal(validators.VMBiosTypeID))
 	})
-	It("should flag vm with unsupported bios type: i440fx_sea_bios ", func() {
+	It("should not flag vm with unsupported bios type: i440fx_sea_bios ", func() {
 		var vm = newVM()
 		bios := ovirtsdk.Bios{}
 		bios.SetType("i440fx_sea_bios")
@@ -111,8 +111,7 @@ var _ = Describe("Validating VM", func() {
 
 		failures := validators.ValidateVM(vm, kvConfig)
 
-		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(validators.VMBiosTypeID))
+		Expect(failures).To(BeEmpty())
 	})
 	It("should flag vm with q35_secure_boot bios ", func() {
 		var vm = newVM()
@@ -133,7 +132,7 @@ var _ = Describe("Validating VM", func() {
 
 		Expect(failures).To(BeEmpty())
 	})
-	It("should flag vm with unsupported cluster default bios type: i440fx_sea_bios ", func() {
+	It("should not flag vm with unsupported cluster default bios type: i440fx_sea_bios ", func() {
 		var vm = newVM()
 		bios := ovirtsdk.Bios{}
 		bios.SetType("cluster_default")
@@ -142,8 +141,7 @@ var _ = Describe("Validating VM", func() {
 
 		failures := validators.ValidateVM(vm, kvConfig)
 
-		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(validators.VMBiosTypeID))
+		Expect(failures).To(BeEmpty())
 	})
 	It("should flag vm with s390x CPU ", func() {
 		var vm = newVM()

--- a/tests/ovirt/various_vm_configurations_test.go
+++ b/tests/ovirt/various_vm_configurations_test.go
@@ -102,7 +102,8 @@ var _ = Describe("Import", func() {
 		},
 			table.Entry("q35_sea_bios", "q35_sea_bios", v1.Bootloader{BIOS: &v1.BIOS{}}),
 			table.Entry("q35_secure_boot", "q35_secure_boot", v1.Bootloader{BIOS: &v1.BIOS{}}),
-			table.Entry("q35_ovmf", "q35_ovmf", v1.Bootloader{EFI: &v1.EFI{}}))
+			table.Entry("q35_ovmf", "q35_ovmf", v1.Bootloader{EFI: &v1.EFI{}}),
+			table.Entry("i440fx_sea_bios", "i440fx_sea_bios", v1.Bootloader{BIOS: &v1.BIOS{}}))
 
 		table.DescribeTable("architecture", func(inArch string, targetArch string) {
 			vmID := vms.ArchitectureVmIDPrefix + inArch

--- a/tests/ovirt/vm_validation_test.go
+++ b/tests/ovirt/vm_validation_test.go
@@ -80,7 +80,6 @@ var _ = Describe("VM validation ", func() {
 		table.Entry("unsupported timezone", vms.UnsupportedTimezoneVmID, "timezone-template.xml", map[string]string{"@TIMEZONE": "America/New_York"}),
 		table.Entry("unsupported s390x architecture", vms.UnsupportedArchitectureVmID, "architecture-template.xml", map[string]string{"@ARCH": "s390x"}),
 		table.Entry("USB enabled", vms.UsbEnabledVmID, "usb-template.xml", map[string]string{"@ENABLED": "true"}),
-		table.Entry("unsupported i440fx_sea_bios BIOS type", vms.UnsupportedBiosTypeVmID, "bios-type-template.xml", map[string]string{"@BIOSTYPE": "i440fx_sea_bios"}),
 		table.Entry("placement policy affinity set to 'migratable'", vms.MigratablePlacementPolicyAffinityVmID, "placement-policy-affinity-template.xml", map[string]string{"@AFFINITY": "migratable"}),
 		table.Entry("kubevirt origin", vms.KubevirtOriginVmID, "origin-template.xml", map[string]string{"@ORIGIN": "kubevirt"}),
 		table.Entry("illegal images", vms.IlleagalImagesVmID, "has-illegal-images-template.xml", map[string]string{"@ILLEGALIMAGES": "true"}),

--- a/tests/ovirt/vms/definitions.go
+++ b/tests/ovirt/vms/definitions.go
@@ -6,7 +6,6 @@ const (
 	InvalidDiskID                                = "invalid"
 	InvalidNicInterfaceVmIDPrefix                = "nic-interface-"
 	UnsupportedStatusVmIDPrefix                  = "unsupported-status-"
-	UnsupportedBiosTypeVmID                      = "unsupported-i440fx_sea_bios-bios-type"
 	UnsupportedArchitectureVmID                  = "unsupported-s390x-architecture"
 	NicPassthroughVmID                           = "nic-passthrough"
 	IlleagalImagesVmID                           = "illegal-images"


### PR DESCRIPTION
We required a user to make sure that source vm uses q35 compatibile bios. Changing the bios do not modify the quest but it may affect device layout upon reboot. We should not affect source vm while importing. This PR allows to import i440fx in the same way as q35.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>