### PR TITLE
Select newest template

### DIFF
--- a/pkg/providers/ovirt/templates/template-finder.go
+++ b/pkg/providers/ovirt/templates/template-finder.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/os"
@@ -58,6 +59,11 @@ func (f *TemplateFinder) getTemplate(os string, workload string) (*templatev1.Te
 	}
 	if len(templates.Items) == 0 {
 		return nil, fmt.Errorf("Template not found for %s OS and %s workload", os, workload)
+	}
+	if len(templates.Items) > 1 {
+		sort.Slice(templates.Items, func(i, j int) bool {
+			return templates.Items[j].CreationTimestamp.Before(&templates.Items[i].CreationTimestamp)
+		})
 	}
 	// Take first which matches label selector
 	return &templates.Items[0], nil


### PR DESCRIPTION
Whenever we select templates we may get more than one for the same labels with this PR we make sure to always used the latest based on template creation timestamp.

Fixes: https://github.com/kubevirt/vm-import-operator/issues/345

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>