### PR TITLE
Permissions issue during HCO deployment

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -274,6 +274,8 @@ func getOperatorPolicyRules() []rbacv1.PolicyRule {
 				"configmaps",
 				"secrets",
 				"serviceaccounts",
+				"services",
+				"services/finalizers",
 			},
 			Verbs: []string{
 				"*",


### PR DESCRIPTION
During running HCO we see:

> Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:kubevirt-hyperconverged:vm-import-operator" cannot list resource "services" in API group "" at the cluster scope

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>