### PR TITLE
Missing permission

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -329,6 +329,18 @@ func getOperatorPolicyRules() []rbacv1.PolicyRule {
 				"*",
 			},
 		},
+		{
+			APIGroups: []string{
+				"monitoring.coreos.com",
+			},
+			Resources: []string{
+				"servicemonitors",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+		},
 	}
 	return rules
 }


### PR DESCRIPTION
During HCO deployment by the CI we see:

> Failed to list *v1.ServiceMonitor: servicemonitors.monitoring.coreos.com is forbidden: User "system:serviceaccount:kubevirt-hyperconverged:vm-import-operator" cannot list resource "servicemonitors" in API group "monitoring.coreos.com" at the cluster scope

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>