### PR TITLE
Allow to watch and create servicemonitors

### DIFF
--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -337,8 +337,7 @@ func getOperatorPolicyRules() []rbacv1.PolicyRule {
 				"servicemonitors",
 			},
 			Verbs: []string{
-				"get",
-				"list",
+				"*",
 			},
 		},
 	}


### PR DESCRIPTION
We need to allow to watch and create servicemonitors.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>