### PR TITLE
Update template finder

### DIFF
--- a/examples/config_map.yaml
+++ b/examples/config_map.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   guestos2common: |
     "Red Hat Enterprise Linux Server": "rhel"
+    "Red Hat Enterprise Linux": "rhel"
     "CentOS Linux": "centos"
     "Fedora": "fedora"
     "Ubuntu": "ubuntu"

--- a/pkg/os/os-mapper-provider.go
+++ b/pkg/os/os-mapper-provider.go
@@ -100,6 +100,7 @@ func (o *OSMaps) updateOsMapsByUserMaps(guestOsToCommon map[string]string, osInf
 func initGuestOsToCommon() map[string]string {
 	return map[string]string{
 		"Red Hat Enterprise Linux Server": "rhel",
+		"Red Hat Enterprise Linux":        "rhel",
 		"CentOS Linux":                    "centos",
 		"Fedora":                          "fedora",
 		"Ubuntu":                          "ubuntu",

--- a/pkg/providers/ovirt/os/os-finder.go
+++ b/pkg/providers/ovirt/os/os-finder.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	defaultLinux   = "rhel8"
-	defaultWindows = "windows"
+	defaultLinux   = "rhel8.2"
+	defaultWindows = "win10"
 )
 
 // OSFinder defines operation of discovering OS name of a VM

--- a/pkg/providers/ovirt/os/os-finder_test.go
+++ b/pkg/providers/ovirt/os/os-finder_test.go
@@ -65,11 +65,11 @@ var _ = Describe("OS finder ", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os).To(BeEquivalentTo(expectedOs))
 	},
-		table.Entry("for generic Linux", "linux X", "rhel8"),
-		table.Entry("for RHEL", "rhel X", "rhel8"),
+		table.Entry("for generic Linux", "linux X", "rhel8.2"),
+		table.Entry("for RHEL", "rhel X", "rhel8.2"),
 
-		table.Entry("for generic Windows", "windows", "windows"),
-		table.Entry("for windows_7", "windows_7", "windows"),
+		table.Entry("for generic Windows", "windows", "win10"),
+		table.Entry("for windows_7", "windows_7", "win10"),
 	)
 
 	It("should return error for os map provider error", func() {

--- a/tests/os-mapping/os-mapping.yaml
+++ b/tests/os-mapping/os-mapping.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   guestos2common: |
     "Red Hat Enterprise Linux Server": "rhel"
+    "Red Hat Enterprise Linux": "rhel"
     "CentOS Linux": "centos"
     "Fedora": "fedora"
     "Ubuntu": "ubuntu"


### PR DESCRIPTION
We update os mapping configMap to contain "Red Hat Enterprise Linux" and we fix os default to be able to match existing templates.

```release-note
None
```

Bug-Url: https://bugzilla.redhat.com/1876503
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>