### PR TITLE
Fixing problem with changed qe-tools sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,3 +87,5 @@ replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
 
 replace sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.2.4
+
+replace kubevirt.io/qe-tools => kubevirt.io/qe-tools v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -1403,8 +1403,8 @@ kubevirt.io/client-go v0.26.2/go.mod h1:1ooQZUI8b9A8CcCRvpekF6Llf66drzK76C57tya6
 kubevirt.io/containerized-data-importer v1.10.6/go.mod h1:qF594BtRRkruyrqLwt3zbLCWdPIQNs1qWh4LR1cOzy0=
 kubevirt.io/containerized-data-importer v1.15.0 h1:6GN4NbQX0VTbG7DcGfOWmW1cHChRkwDiaIq1nOtPBoU=
 kubevirt.io/containerized-data-importer v1.15.0/go.mod h1:Sl6HMDIzQZ/psSKj/CjjgVWlQHFVLfHXIxeoQEGqshk=
-kubevirt.io/qe-tools v0.1.3 h1:ZDDolkD2IsHuPW8PNyty5fWO6wpI2BXcQpC65en/9FU=
-kubevirt.io/qe-tools v0.1.3/go.mod h1:PJyH/YXC4W0AmxfheDmXWMbLNsMSboVGXKpMAwfKzVE=
+kubevirt.io/qe-tools v0.1.6 h1:S6z9CATmgV2/z9CWetij++Rhu7l/Z4ObZqerLdNMo0Y=
+kubevirt.io/qe-tools v0.1.6/go.mod h1:PJyH/YXC4W0AmxfheDmXWMbLNsMSboVGXKpMAwfKzVE=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=


### PR DESCRIPTION
Downloaded sum of qe-tools v0.1.3 was different than one stored in go.sum.

```release-note
NONE
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>