### PR TITLE
Use label normalizer

### DIFF
--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -134,7 +134,7 @@ func (o *OvirtMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMach
 
 	// Map hostname
 	if fqdn, ok := o.vm.Fqdn(); ok {
-		name, _ := utils.NormalizeName(fqdn)
+		name, _ := utils.NormalizeLabel(fqdn)
 		vmSpec.Spec.Template.Spec.Hostname = name
 	}
 

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should normalize hostname", func() {
 		fqdn := "rhev-orange-03.rdu2.scalelab.redhat.com"
-		norm, _ := utils.NormalizeName(fqdn)
+		norm, _ := utils.NormalizeLabel(fqdn)
 		vm = createVM()
 		vm.SetFqdn(fqdn)
 


### PR DESCRIPTION
Name normalizer validation accepts fqdns which are not valid for labels. Apparently vm.Spec.Template.Spec.Hostname user label not name semantics.

In the previous change it seems it was tested without guest agent.

Bug-Url: https://bugzilla.redhat.com/1877685
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>