### PR TITLE
Do not override machine type for i440fx

### DIFF
--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -515,7 +515,10 @@ func (o *OvirtMapper) mapArchitecture() *kubevirtv1.Machine {
 
 	// Override machine type in case custom emulated machine is specified
 	if custom, ok := o.vm.CustomEmulatedMachine(); ok {
-		machine.Type = custom
+		// do not override when i440fx which is unsupported
+		if !strings.Contains(custom, "i440fx") {
+			machine.Type = custom
+		}
 	}
 
 	return machine

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -98,6 +98,16 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		Expect(vmSpecCPU.Threads).To(Equal(uint32(vmTopology.MustThreads())))
 	})
 
+	It("should not override machine type", func() {
+		vm = createVM()
+		vm.SetCustomEmulatedMachine("pc-i440fx-rhel7.6.0")
+
+		mapper := mapper.NewOvirtMapper(vm, &mappings, mapper.DataVolumeCredentials{}, "", &osFinder)
+		vmSpec, _ = mapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
+
+		Expect(vmSpec.Spec.Template.Spec.Domain.Machine.Type).To(Equal("q35"))
+	})
+
 	It("should map CPU pinning", func() {
 		vm = createVM()
 		vm.MustCpu().SetCpuTune(
@@ -536,6 +546,7 @@ func createVMGeneric(affinity ovirtsdk.VmAffinity, readonly bool, biostype ovirt
 						Sockets(2).
 						Threads(4).
 						MustBuild()).
+				Architecture(ovirtsdk.ARCHITECTURE_X86_64).
 				MustBuild()).
 		HighAvailability(
 			ovirtsdk.NewHighAvailabilityBuilder().

--- a/pkg/providers/ovirt/validation/validators/definitions.go
+++ b/pkg/providers/ovirt/validation/validators/definitions.go
@@ -77,6 +77,8 @@ const (
 	VMMemoryPolicyOvercommitPercentID = CheckID("vm.memory_policy.over_commit.percent")
 	// VMMemoryPolicyGuaranteedID defines an ID of a vm.memory_policy.guaranteed check
 	VMMemoryPolicyGuaranteedID = CheckID("vm.memory_policy.guaranteed")
+	// VMCustomEmulatedMachine defines machine type
+	VMCustomEmulatedMachine = CheckID("vm.machine.type")
 	// VMMemoryTemplateLimitID defines that vm memory is below template requirements
 	VMMemoryTemplateLimitID = CheckID("vm.memory template.requests")
 	// VMMigrationID defines an ID of a vm.migration check

--- a/pkg/providers/ovirt/validation/validators/vm-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator_test.go
@@ -494,6 +494,15 @@ var _ = Describe("Validating VM", func() {
 		Expect(failures).To(HaveLen(1))
 		Expect(failures[0].ID).To(Equal(validators.VMMemoryTemplateLimitID))
 	})
+	It("should flag custom emulated machne type when i440fx used", func() {
+		var vm = newVM()
+		vm.SetCustomEmulatedMachine("pc-i440fx-rhel7.6.0")
+
+		failures := validators.ValidateVM(vm, kvConfig, templateFinder)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.VMCustomEmulatedMachine))
+	})
 })
 
 func newGraphicsConsole(protocol string) *ovirtsdk.GraphicsConsole {

--- a/pkg/providers/ovirt/validation/vm-import-validation.go
+++ b/pkg/providers/ovirt/validation/vm-import-validation.go
@@ -68,6 +68,7 @@ var checkToAction = map[validators.CheckID]action{
 	validators.VMCpuArchitectureID:               block,
 	validators.VMCpuTuneID:                       warn,
 	validators.VMCpuSharesID:                     log,
+	validators.VMCustomEmulatedMachine:           log,
 	validators.VMCustomPropertiesID:              warn,
 	validators.VMDisplayTypeID:                   log,
 	validators.VMHasIllegalImagesID:              block,


### PR DESCRIPTION
Custom emulated machine is used to override machine type we should not allow to happen when i440fx is used.

Bug-Url: https://bugzilla.redhat.com/1868073
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>