### PR TITLE
Use Privileged ServiceAccount for guest conversion

### DIFF
--- a/pkg/config/controller/config.go
+++ b/pkg/config/controller/config.go
@@ -8,6 +8,9 @@ const (
 
 	// OsConfigMapNameKey defines the configuration key for the OS mapping config map name
 	OsConfigMapNameKey = "osConfigMap.name"
+
+	// PrivilegedSANameKey defines the configuration key for the privileged service account to use for guest conversion
+	PrivilegedSANameKey = "privilegedServiceAccount.name"
 )
 
 // ControllerConfig stores controller runtime configuration
@@ -30,4 +33,9 @@ func (c ControllerConfig) OsConfigMapNamespace() string {
 // OsConfigMapName provides name of the the OS mapping ConfigMap. Empty string is returned when the name is not present.
 func (c ControllerConfig) OsConfigMapName() string {
 	return c.ConfigMap.Data[OsConfigMapNameKey]
+}
+
+// PrivilegedSAName providess the name of the privileged service account to use for guest conversion.
+func (c ControllerConfig) PrivilegedSAName() string {
+	return c.ConfigMap.Data[PrivilegedSANameKey]
 }

--- a/pkg/guestconversion/guestconversion_test.go
+++ b/pkg/guestconversion/guestconversion_test.go
@@ -36,7 +36,7 @@ var _ = Describe("GuestConversion", func() {
 		})
 
 		It("should create a volume and mount for the libvirt domain config map", func() {
-			job := MakeGuestConversionJobSpec(vmSpec, configMap)
+			job := MakeGuestConversionJobSpec(vmSpec, configMap, "")
 			Expect(len(job.Spec.Template.Spec.Volumes)).To(Equal(1))
 			Expect(job.Spec.Template.Spec.Volumes[0].Name).To(Equal(configMapVolumeName))
 			Expect(job.Spec.Template.Spec.Volumes[0].ConfigMap).ToNot(BeNil())
@@ -60,7 +60,7 @@ var _ = Describe("GuestConversion", func() {
 					},
 				},
 			}
-			job := MakeGuestConversionJobSpec(vmSpec, configMap)
+			job := MakeGuestConversionJobSpec(vmSpec, configMap, "")
 			Expect(len(job.Spec.Template.Spec.Volumes)).To(Equal(3))
 			Expect(job.Spec.Template.Spec.Volumes[0].Name).To(Equal("dv-1"))
 			Expect(job.Spec.Template.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal("dv-1"))


### PR DESCRIPTION
This adds a key to the vm-import-controller-config configmap, `privilegedServiceAccount.name`. When creating the guest conversion job the provider will check for the presence of the privileged service account in the target namespace. If it exists, the job
will be run as that SA so that it can mount `/dev/kvm` on the host. This significantly speeds up the guest conversion process.