### PR TITLE
Install the latest version of CDI on the test cluster

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -9,7 +9,7 @@ function debug {
 }
 
 function install_cdi {
-    export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+    export VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | jq 'sort_by(.tag_name) | .[-1].tag_name' -r)
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
     ./cluster/kubectl.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
     ./cluster/kubectl.sh wait cdis.cdi.kubevirt.io/cdi --for=condition=Available --timeout=1200s || debug cdi


### PR DESCRIPTION
Curling from `/releases/latest` on Github is not reliable because point releases of older versions can appear as the latest release. Currently, `1.18.3` is returned when querying Github for the latest version, which breaks our tests. 

This change gets a list of releases from the API, sorts them by tag, and takes the latest.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>