### PR TITLE
vSphere: FindTemplate should search for a desktop template if no server templates are found

### DIFF
--- a/pkg/providers/vmware/provider_test.go
+++ b/pkg/providers/vmware/provider_test.go
@@ -3,6 +3,7 @@ package vmware
 import (
 	"context"
 	"encoding/json"
+	"github.com/onsi/ginkgo/extensions/table"
 
 	"github.com/ghodss/yaml"
 	"github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
@@ -462,70 +463,75 @@ var _ = Describe("TestConnection", func() {
 	})
 })
 
-var _ = Describe("Processing a template", func() {
+var _ = table.DescribeTable("Processing a template", func(workloadLabel string) {
+
 	provider := VmwareProvider{}
+	model := simulator.VPX()
+	_ = model.Create()
+	server := model.Service.NewServer()
+	client, _ := govmomi.NewClient(context.TODO(), server.URL, false)
 
-	BeforeEach(func() {
-		model := simulator.VPX()
-		_ = model.Create()
-		server := model.Service.NewServer()
-		client, _ := govmomi.NewClient(context.TODO(), server.URL, false)
+	simVm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	simVm.Guest.GuestId = "rhel7Guest"
+	simulator.Map.Put(simVm)
 
-		simVm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-		simVm.Guest.GuestId = "rhel7Guest"
-		simulator.Map.Put(simVm)
+	username := server.URL.User.Username()
+	password, _ := server.URL.User.Password()
+	richClient, _ := vclient.NewRichVMWareClient(server.URL.String(), username, password, "")
+	provider.vmwareClient = richClient
+	provider.vm = object.NewVirtualMachine(client.Client, simVm.Reference())
+	templateProvider := &mockTemplateProvider{}
+	provider.templateHandler = templates.NewTemplateHandler(templateProvider)
+	provider.templateFinder = vtemplates.NewTemplateFinder(templateProvider, &mockOsFinder{})
 
-		username := server.URL.User.Username()
-		password, _ := server.URL.User.Password()
-		richClient, _ := vclient.NewRichVMWareClient(server.URL.String(), username, password, "")
-		provider.vmwareClient = richClient
-		provider.vm = object.NewVirtualMachine(client.Client, simVm.Reference())
-		templateProvider := &mockTemplateProvider{}
-		provider.templateHandler = templates.NewTemplateHandler(templateProvider)
-		provider.templateFinder = vtemplates.NewTemplateFinder(templateProvider, &mockOsFinder{})
-	})
-
-	It("should process a template", func() {
-		vmName := "test"
-		namespace := "default"
-		template := templatev1.Template{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rhel7.7-server-medium",
-				Namespace: "kubevirt-hyperconverged",
-				Annotations: map[string]string{
-					"name.os.template.kubevirt.io/rhel7.7": "Red Hat Enterprise Linux 7.7",
-				},
+	vmName := "test"
+	namespace := "default"
+	template := templatev1.Template{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-template-name",
+			Namespace: "kubevirt-hyperconverged",
+			Annotations: map[string]string{
+				"name.os.template.kubevirt.io/rhel7.7": "Red Hat Enterprise Linux 7.7",
 			},
-		}
+			Labels: map[string]string{
+				"os.template.kubevirt.io/rhel7.7":    "true",
+				"flavor.template.kubevirt.io/medium": "true",
+				workloadLabel:                        "true",
+			},
+		},
+	}
 
-		vm, err := provider.ProcessTemplate(&template, &vmName, namespace)
-		Expect(err).To(BeNil())
-		vmLabels := map[string]string{
-			"flavor.template.kubevirt.io/medium":   "true",
-			"os.template.kubevirt.io/rhel7.7":      "true",
-			"workload.template.kubevirt.io/server": "true",
-			"app":                                  "test",
-			"vm.kubevirt.io/template":              "rhel7.7-server-medium",
-			"vm.kubevirt.io/template.namespace":    "kubevirt-hyperconverged",
-			"vm.kubevirt.io/template.revision":     "1",
-			"vm.kubevirt.io/template.version":      "v0.10.0",
-		}
-		specLabels := map[string]string{
-			"workload.template.kubevirt.io/server": "true",
-			"flavor.template.kubevirt.io/medium":   "true",
-			"kubevirt.io/domain":                   "test",
-			"kubevirt.io/size":                     "medium",
-			"os.template.kubevirt.io/rhel7.7":      "true",
-			"vm.kubevirt.io/name":                  "test",
-		}
-		annotations := map[string]string{
-			"name.os.template.kubevirt.io/rhel7.7": "Red Hat Enterprise Linux 7.7",
-		}
-		Expect(vm.ObjectMeta.GetLabels()).Should(Equal(vmLabels))
-		Expect(vm.Spec.Template.ObjectMeta.GetLabels()).Should(Equal(specLabels))
-		Expect(vm.ObjectMeta.GetAnnotations()).Should(Equal(annotations))
-	})
-})
+	vm, err := provider.ProcessTemplate(&template, &vmName, namespace)
+	Expect(err).To(BeNil())
+	vmLabels := map[string]string{
+		workloadLabel:                        "true",
+		"flavor.template.kubevirt.io/medium": "true",
+		"os.template.kubevirt.io/rhel7.7":    "true",
+		"app":                                "test",
+		"vm.kubevirt.io/template":            "my-template-name",
+		"vm.kubevirt.io/template.namespace":  "kubevirt-hyperconverged",
+		"vm.kubevirt.io/template.revision":   "1",
+		"vm.kubevirt.io/template.version":    "v0.10.0",
+	}
+	specLabels := map[string]string{
+		workloadLabel:                        "true",
+		"flavor.template.kubevirt.io/medium": "true",
+		"kubevirt.io/domain":                 "test",
+		"kubevirt.io/size":                   "medium",
+		"os.template.kubevirt.io/rhel7.7":    "true",
+		"vm.kubevirt.io/name":                "test",
+	}
+	annotations := map[string]string{
+		"name.os.template.kubevirt.io/rhel7.7": "Red Hat Enterprise Linux 7.7",
+	}
+	Expect(vm.ObjectMeta.GetLabels()).Should(Equal(vmLabels))
+	Expect(vm.Spec.Template.ObjectMeta.GetLabels()).Should(Equal(specLabels))
+	Expect(vm.ObjectMeta.GetAnnotations()).Should(Equal(annotations))
+
+},
+	table.Entry("Desktop", "workload.template.kubevirt.io/desktop"),
+	table.Entry("Server", "workload.template.kubevirt.io/server"),
+)
 
 type mockOsFinder struct{}
 
@@ -548,7 +554,7 @@ func (t *mockTemplateProvider) Process(_ string, _ *string, _ *templatev1.Templa
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"app":                               "test",
-				"vm.kubevirt.io/template":           "rhel7.7-server-medium",
+				"vm.kubevirt.io/template":           "my-template-name",
 				"vm.kubevirt.io/template.namespace": "kubevirt-hyperconverged",
 				"vm.kubevirt.io/template.revision":  "1",
 				"vm.kubevirt.io/template.version":   "v0.10.0",


### PR DESCRIPTION
The vSphere provider FindTemplate method should pass a nil workload to the template provider, since it can't get the workload from the vSphere API and setting a default can result in failing to find a valid template.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1890486

Signed-off-by: Sam Lucidi <slucidi@redhat.com>