### PR TITLE
vSphere: always map machine type to q35

### DIFF
--- a/pkg/providers/vmware/mapper/mapper.go
+++ b/pkg/providers/vmware/mapper/mapper.go
@@ -41,6 +41,11 @@ const (
 	networkTypePod    = "pod"
 )
 
+// architectures
+const (
+	q35 = "q35"
+)
+
 var biosTypeMapping = map[string]*kubevirtv1.Bootloader{
 	"efi":  {EFI: &kubevirtv1.EFI{}},
 	"bios": {BIOS: &kubevirtv1.BIOS{}},
@@ -427,6 +432,7 @@ func (r *VmwareMapper) MapVM(targetVmName *string, vmSpec *kubevirtv1.VirtualMac
 	nameParts := strings.Split(hostname, ".")
 	vmSpec.Spec.Template.Spec.Hostname = nameParts[0]
 
+	vmSpec.Spec.Template.Spec.Domain.Machine = kubevirtv1.Machine{Type: q35}
 	vmSpec.Spec.Template.Spec.Domain.CPU = r.mapCPUTopology()
 	vmSpec.Spec.Template.Spec.Domain.Firmware = r.mapFirmware()
 	vmSpec.Spec.Template.Spec.Domain.Features = r.mapFeatures()

--- a/pkg/providers/vmware/mapper/mapper_test.go
+++ b/pkg/providers/vmware/mapper/mapper_test.go
@@ -27,6 +27,7 @@ var (
 	cpuCores             int32 = 1
 	cpuSockets           int32 = 4
 	gmtOffsetSeconds     int32 = 3600
+	machineType                = "q35"
 
 	// networks
 	networkName              = "VM Network"
@@ -127,6 +128,15 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 		quantity, _ := resource.ParseQuantity(memoryReservationStr)
 		Expect(vmSpec.Spec.Template.Spec.Domain.Resources.Requests.Memory().Value()).To(Equal(quantity.Value()))
+	})
+
+	It("should map machine type", func() {
+		mappings := createMinimalMapping()
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
+		Expect(err).To(BeNil())
+
+		Expect(vmSpec.Spec.Template.Spec.Domain.Machine.Type).To(Equal(machineType))
 	})
 
 	It("should map CPU topology", func() {


### PR DESCRIPTION
This overwrites the machine type that might be set by the template the VM is based on, in order to avoid the VM failing to start due to an unsupported machine type.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>