### PR TITLE
Requque when VMI not yet created

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -592,7 +592,7 @@ var _ = Describe("Reconcile steps", func() {
 		It("should not start vm: ", func() {
 			instance.Status.Conditions = []v2vv1.VirtualMachineImportCondition{}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(BeNil())
 		})
@@ -602,7 +602,7 @@ var _ = Describe("Reconcile steps", func() {
 				return fmt.Errorf("Not found")
 			}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -620,7 +620,7 @@ var _ = Describe("Reconcile steps", func() {
 				return fmt.Errorf("Not modified")
 			}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -643,7 +643,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -660,7 +660,7 @@ var _ = Describe("Reconcile steps", func() {
 				return fmt.Errorf("Not modified")
 			}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -677,7 +677,7 @@ var _ = Describe("Reconcile steps", func() {
 				return fmt.Errorf("Not modified")
 			}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(Not(BeNil()))
 		})
@@ -719,7 +719,7 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
-			err := reconciler.startVM(mock, instance, vmName)
+			_, err := reconciler.startVM(mock, instance, vmName)
 
 			Expect(err).To(BeNil())
 		})

--- a/tests/matchers/vm-import.go
+++ b/tests/matchers/vm-import.go
@@ -56,6 +56,19 @@ func HaveValidationFailure(testFramework *framework.Framework, reason string) ty
 	return &matcher
 }
 
+// HaveRunningVM creates the matcher checking whether Virtual Machine Instance is running
+func HaveRunningVM(testFramework *framework.Framework) types.GomegaMatcher {
+	matcher := hasConditionInStatus{}
+	matcher.timeout = 1 * time.Minute
+	matcher.pollInterval = 1 * time.Second
+	matcher.testFramework = testFramework
+
+	matcher.conditionType = v2vv1.Succeeded
+	matcher.status = corev1.ConditionTrue
+	matcher.reason = string(v2vv1.VirtualMachineRunning)
+	return &matcher
+}
+
 // BeProcessing creates the matcher checking whether Virtual Machine Import is currently processing
 func BeProcessing(testFramework *framework.Framework) types.GomegaMatcher {
 	matcher := hasConditionInStatus{}

--- a/tests/ovirt/basic_vm_import_test.go
+++ b/tests/ovirt/basic_vm_import_test.go
@@ -88,6 +88,8 @@ var _ = Describe("Basic VM import ", func() {
 
 			vm := test.validateTargetConfiguration(vmBlueprint.Name)
 			Expect(vm.Spec.Template.Spec.Volumes[0].DataVolume.Name).To(HaveDefaultStorageClass(f))
+
+			Expect(retrieved).To(HaveRunningVM(f))
 		})
 	})
 
@@ -110,6 +112,8 @@ var _ = Describe("Basic VM import ", func() {
 
 			vm := test.validateTargetConfiguration(vmBlueprint.Name)
 			Expect(vm.Spec.Template.Spec.Volumes[0].DataVolume.Name).To(HaveStorageClass(storageClass, f))
+
+			Expect(retrieved).To(HaveRunningVM(f))
 		},
 			table.Entry(" for disk", v2vv1.OvirtMappings{
 				DiskMappings: &[]v2vv1.StorageResourceMappingItem{


### PR DESCRIPTION
Sometimes it may take some time for vmi to be created and scheduled. We need to make sure vmi was created and check its status to update vm import conditions correctly.

New logging statements added to improve supportability.

Fixes: https://github.com/kubevirt/vm-import-operator/issues/344
Bug-Url: https://bugzilla.redhat.com/1884249
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>