### PR TITLE
Add CreateVMSnapshot to Provider interface

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -63,6 +63,8 @@ var (
 	needsGuestConversion     func() bool
 	getGuestConversionJob    func() (*batchv1.Job, error)
 	launchGuestConversionJob func() (*batchv1.Job, error)
+	supportsWarmMigration    func() bool
+	createVMSnapshot         func() (string, error)
 )
 
 var _ = Describe("Reconcile steps", func() {
@@ -1933,6 +1935,14 @@ func (p *mockProvider) GetGuestConversionJob() (*batchv1.Job, error) {
 
 func (p *mockProvider) LaunchGuestConversionJob(_ *kubevirtv1.VirtualMachine) (*batchv1.Job, error) {
 	return launchGuestConversionJob()
+}
+
+func (p *mockProvider) SupportsWarmMigration() bool {
+	return supportsWarmMigration()
+}
+
+func (p *mockProvider) CreateVMSnapshot() (string, error) {
+	return createVMSnapshot()
 }
 
 // CreateEmptyVM implements Mapper.CreateEmptyVM

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -397,16 +397,29 @@ func (o *OvirtProvider) CleanUp(failure bool, cr *v2vv1.VirtualMachineImport, cl
 	return nil
 }
 
+// NeedsGuestConversion indicates whether a VM from this provider must undergo guest conversion.
 func (o *OvirtProvider) NeedsGuestConversion() bool {
 	return false
 }
 
+// GetGuestConversionJob is not implemented.
 func (o *OvirtProvider) GetGuestConversionJob() (*batchv1.Job, error) {
 	return nil, nil
 }
 
+// LaunchGuestConversionJob is not implemented.
 func (o *OvirtProvider) LaunchGuestConversionJob(_ *kubevirtv1.VirtualMachine) (*batchv1.Job, error) {
 	return nil, nil
+}
+
+// SupportsWarmMigration returns whether this provider supports warm migrations.
+func (o *OvirtProvider) SupportsWarmMigration() bool {
+	return false
+}
+
+// CreateVMSnapshot is not implemented.
+func (o *OvirtProvider) CreateVMSnapshot() (string, error) {
+	return "", nil
 }
 
 func (o *OvirtProvider) prepareDataVolumeCredentials() (mapper.DataVolumeCredentials, error) {

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -38,6 +38,8 @@ type Provider interface {
 	NeedsGuestConversion() bool
 	GetGuestConversionJob() (*batchv1.Job, error)
 	LaunchGuestConversionJob(*kubevirtv1.VirtualMachine) (*batchv1.Job, error)
+	SupportsWarmMigration() bool
+	CreateVMSnapshot() (string, error)
 }
 
 // Mapper is interface to be used for mapping external VM to kubevirt VM

--- a/pkg/providers/vmware/client/client.go
+++ b/pkg/providers/vmware/client/client.go
@@ -109,6 +109,24 @@ func (r RichVmwareClient) getVMByInventoryPath(vmPath string) (*object.VirtualMa
 	return vm, nil
 }
 
+// CreateVMSnapshot creates a snapshot of the VM.
+func (r RichVmwareClient) CreateVMSnapshot(moRef string, name string, desc string, memory bool, quiesce bool) (*types.ManagedObjectReference, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	vm := r.getVMByMoRef(moRef)
+	task, err := vm.CreateSnapshot(ctx, name, desc, memory, quiesce)
+	if err != nil {
+		return nil, err
+	}
+	res, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	snapshotRef := res.Result.(types.ManagedObjectReference)
+	return &snapshotRef, nil
+}
+
 // GetVMProperties retrieves the Properties struct for the VM.
 func (r RichVmwareClient) GetVMProperties(vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/providers/vmware/client/client_test.go
+++ b/pkg/providers/vmware/client/client_test.go
@@ -117,6 +117,25 @@ var _ = Describe("Test VMware rich client", func() {
 		Entry("ESXi", simulator.ESX()),
 	)
 
+	DescribeTable("should create a snapshot for a VM", func(model *simulator.Model) {
+		_ = model.Create()
+		server := model.Service.NewServer()
+		defer model.Remove()
+		defer server.Close()
+		richClient, err := createRichClient(server)
+		Expect(err).To(BeNil())
+		moRef, _ := getVMIdentifiers()
+
+		snapshotRef, err := richClient.CreateVMSnapshot(moRef, "name", "description", false, true)
+		Expect(err).To(BeNil())
+		Expect(snapshotRef).ToNot(BeNil())
+		Expect(snapshotRef.Type).To(Equal("VirtualMachineSnapshot"))
+		Expect(snapshotRef.Value[0:9]).To(Equal("snapshot-"))
+	},
+		Entry("vCenter", simulator.VPX()),
+		Entry("ESXi", simulator.ESX()),
+	)
+
 	DescribeTable("should power off and on a VM by ID", func(model *simulator.Model) {
 		_ = model.Create()
 		server := model.Service.NewServer()

--- a/pkg/providers/vmware/provider.go
+++ b/pkg/providers/vmware/provider.go
@@ -47,6 +47,9 @@ const (
 	keySecretKey    = "secretKey"
 	thumbprintKey   = "thumbprint"
 	vmwareSecretKey = "vmware"
+
+	warmMigrationSnapshotName        = "warm-migration-stage"
+	warmMigrationSnapshotDescription = "VM Import Operator warm migration stage"
 )
 
 // VmwareProvider is VMware implementation of the Provider interface to support importing VMs from VMware
@@ -265,6 +268,24 @@ func (r *VmwareProvider) StopVM(instance *v1beta1.VirtualMachineImport, client c
 	}
 
 	return nil
+}
+
+// CreateVMSnapshot creates a snapshot to use in a warm migration.
+func (r *VmwareProvider) CreateVMSnapshot() (string, error) {
+	vm, err := r.getVM()
+	if err != nil {
+		return "", err
+	}
+
+	snapshotRef, err := r.vmwareClient.CreateVMSnapshot(vm.Reference().Value, warmMigrationSnapshotName, warmMigrationSnapshotDescription, false, true)
+	if err != nil {
+		return "", err
+	}
+	return snapshotRef.Value, nil
+}
+
+func (r *VmwareProvider) SupportsWarmMigration() bool {
+	return true
 }
 
 // CleanUp removes transient resources created for import

--- a/pkg/providers/vmware/provider_test.go
+++ b/pkg/providers/vmware/provider_test.go
@@ -259,6 +259,59 @@ var _ = Describe("GetVMName", func() {
 	})
 })
 
+var _ = Describe("CreateVMSnapshot", func() {
+	var provider *VmwareProvider
+	var model *simulator.Model
+	var server *simulator.Server
+
+	BeforeEach(func() {
+		model, server, provider = makeProvider()
+	})
+
+	AfterEach(func() {
+		server.Close()
+		model.Remove()
+	})
+
+	It("Should create a snapshot of a VM that is identified by UUID", func() {
+		vm := getSimulatorVM()
+		_, uuid, _ := getSimulatorVMIdentifiers(vm)
+		provider.instance.Spec.Source = v1beta1.VirtualMachineImportSourceSpec{
+			Vmware: &v1beta1.VirtualMachineImportVmwareSourceSpec{
+				VM: v1beta1.VirtualMachineImportVmwareSourceVMSpec{
+					ID:   &uuid,
+					Name: nil,
+				},
+			},
+		}
+
+		Expect(provider.vm).To(BeNil())
+		snapshotRef, err := provider.CreateVMSnapshot()
+		Expect(err).To(BeNil())
+		Expect(provider.vm).ToNot(BeNil())
+		Expect(snapshotRef[0:9]).To(Equal("snapshot-"))
+	})
+
+	It("Should create a snapshot of a VM that is identified by Name", func() {
+		vm := getSimulatorVM()
+		_, _, name := getSimulatorVMIdentifiers(vm)
+		provider.instance.Spec.Source = v1beta1.VirtualMachineImportSourceSpec{
+			Vmware: &v1beta1.VirtualMachineImportVmwareSourceSpec{
+				VM: v1beta1.VirtualMachineImportVmwareSourceVMSpec{
+					ID:   nil,
+					Name: &name,
+				},
+			},
+		}
+
+		Expect(provider.vm).To(BeNil())
+		snapshotRef, err := provider.CreateVMSnapshot()
+		Expect(err).To(BeNil())
+		Expect(provider.vm).ToNot(BeNil())
+		Expect(snapshotRef[0:9]).To(Equal("snapshot-"))
+	})
+})
+
 var _ = Describe("GetVMStatus", func() {
 	var provider *VmwareProvider
 	var model *simulator.Model


### PR DESCRIPTION
This is laying some of the initial groundwork for Warm Migration.
https://github.com/kubevirt/vm-import-operator/issues/216

* Adds CreateVMSnapshot and SupportsWarmMigration to the Provider interface.
* Implements CreateVMSnapshot and SupportsWarmMigration for the vSphere provider.
* Stubs out CreateVMSnapshot and returns false for SupportsWarmMigration for the oVirt provider.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>