### PR TITLE
Add optional AccessMode to StorageResourceMappingItem

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -895,7 +895,6 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/apis/v2v/v1beta1/resourcemapping_types.go
+++ b/pkg/apis/v2v/v1beta1/resourcemapping_types.go
@@ -93,6 +93,8 @@ type StorageResourceMappingItem struct {
 
 	// +optional
 	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode,omitempty"`
+	// +optional
+	AccessMode *corev1.PersistentVolumeAccessMode `json:"accessMode,omitempty"`
 }
 
 // ResourceMappingStatus defines the observed state of ResourceMapping

--- a/pkg/apis/v2v/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v2v/v1beta1/zz_generated.deepcopy.go
@@ -272,6 +272,11 @@ func (in *StorageResourceMappingItem) DeepCopyInto(out *StorageResourceMappingIt
 		*out = new(v1.PersistentVolumeMode)
 		**out = **in
 	}
+	if in.AccessMode != nil {
+		in, out := &in.AccessMode, &out.AccessMode
+		*out = new(v1.PersistentVolumeAccessMode)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"fmt"
+
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -2220,6 +2220,9 @@ func CreateVMImport() *extv1.CustomResourceDefinition {
 																				"volumeMode": {
 																					Type: "string",
 																				},
+																				"accessMode": {
+																					Type: "string",
+																				},
 																			},
 																			Required: []string{"source"},
 																		},
@@ -2264,6 +2267,9 @@ func CreateVMImport() *extv1.CustomResourceDefinition {
 																					Type: "string",
 																				},
 																				"volumeMode": {
+																					Type: "string",
+																				},
+																				"accessMode": {
 																					Type: "string",
 																				},
 																			},
@@ -2394,6 +2400,9 @@ NetworkMappings.Source.ID represents the macAddress field of the network adapter
 																				"volumeMode": {
 																					Type: "string",
 																				},
+																				"accessMode": {
+																					Type: "string",
+																				},
 																			},
 																			Required: []string{"source"},
 																		},
@@ -2438,6 +2447,9 @@ DiskMappings.Source.ID represents the DiskObjectId or vDiskID of the VirtualDisk
 																					Type: "string",
 																				},
 																				"volumeMode": {
+																					Type: "string",
+																				},
+																				"accessMode": {
 																					Type: "string",
 																				},
 																			},
@@ -2867,6 +2879,9 @@ func CreateResourceMapping() *extv1.CustomResourceDefinition {
 																"volumeMode": {
 																	Type: "string",
 																},
+																"accessMode": {
+																	Type: "string",
+																},
 															},
 															Required: []string{"source", "target"},
 														},
@@ -2911,6 +2926,9 @@ func CreateResourceMapping() *extv1.CustomResourceDefinition {
 																	Type: "string",
 																},
 																"volumeMode": {
+																	Type: "string",
+																},
+																"accessMode": {
 																	Type: "string",
 																},
 															},
@@ -3006,6 +3024,9 @@ NetworkMappings.Source.ID represents the macAddress field of the network adapter
 																"volumeMode": {
 																	Type: "string",
 																},
+																"accessMode": {
+																	Type: "string",
+																},
 															},
 															Required: []string{"source", "target"},
 														},
@@ -3050,6 +3071,9 @@ DiskMappings.Source.ID represents the DiskObjectId or vDiskID of the VirtualDisk
 																	Type: "string",
 																},
 																"volumeMode": {
+																	Type: "string",
+																},
+																"accessMode": {
 																	Type: "string",
 																},
 															},

--- a/pkg/providers/vmware/mapper/mapper_test.go
+++ b/pkg/providers/vmware/mapper/mapper_test.go
@@ -3,6 +3,8 @@ package mapper_test
 import (
 	"context"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	"github.com/kubevirt/vm-import-operator/pkg/providers/vmware/mapper"
 	"github.com/kubevirt/vm-import-operator/pkg/providers/vmware/os"
@@ -39,8 +41,15 @@ var (
 
 	// disks
 	expectedNumDisks  = 2
+	diskId1           = "disk-202-0"
+	diskId2           = "disk-202-1"
 	expectedDiskName1 = "basic-vm-disk-202-0"
 	expectedDiskName2 = "basic-vm-disk-202-1"
+
+	volumeModeBlock      = v1.PersistentVolumeBlock
+	volumeModeFilesystem = v1.PersistentVolumeFilesystem
+	accessModeRWO        = v1.ReadWriteOnce
+	accessModeRWM        = v1.ReadWriteMany
 )
 
 type mockOsFinder struct{}
@@ -250,13 +259,40 @@ var _ = Describe("Test mapping disks", func() {
 		credentials = prepareCredentials(server)
 	})
 
-	It("should map disks", func() {
+	It("should map datavolumes", func() {
+		storageClass := "mystorageclass"
 		mappings := createMinimalMapping()
+		mappings.DiskMappings = &[]v1beta1.StorageResourceMappingItem{
+			{
+				Source: v1beta1.Source{
+					Name: &diskId1,
+				},
+				Target: v1beta1.ObjectIdentifier{
+					Name: storageClass,
+				},
+				VolumeMode: &volumeModeBlock,
+				AccessMode: &accessModeRWM,
+			},
+			{
+				// using defaults
+				Source: v1beta1.Source{
+					Name: &diskId2,
+				},
+			},
+		}
 		mapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
 		dvs, _ := mapper.MapDataVolumes(&targetVMName)
 		Expect(dvs).To(HaveLen(expectedNumDisks))
 		Expect(dvs).To(HaveKey(expectedDiskName1))
 		Expect(dvs).To(HaveKey(expectedDiskName2))
+		// check that mapped options are set correctly
+		Expect(dvs[expectedDiskName1].Spec.PVC.VolumeMode).To(Equal(&volumeModeBlock))
+		Expect(dvs[expectedDiskName1].Spec.PVC.AccessModes[0]).To(Equal(accessModeRWM))
+		Expect(dvs[expectedDiskName1].Spec.PVC.StorageClassName).To(Equal(&storageClass))
+		// check that defaults are set correctly
+		Expect(dvs[expectedDiskName2].Spec.PVC.VolumeMode).To(Equal(&volumeModeFilesystem))
+		Expect(dvs[expectedDiskName2].Spec.PVC.AccessModes[0]).To(Equal(accessModeRWO))
+		Expect(dvs[expectedDiskName2].Spec.PVC.StorageClassName).To(BeNil())
 	})
 })
 

--- a/pkg/providers/vmware/provider_test.go
+++ b/pkg/providers/vmware/provider_test.go
@@ -3,6 +3,7 @@ package vmware
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/onsi/ginkgo/extensions/table"
 
 	"github.com/ghodss/yaml"

--- a/pkg/providers/vmware/templates/template-finder.go
+++ b/pkg/providers/vmware/templates/template-finder.go
@@ -2,11 +2,12 @@ package templates
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/kubevirt/vm-import-operator/pkg/providers/vmware/os"
 	"github.com/kubevirt/vm-import-operator/pkg/templates"
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/vmware/govmomi/vim25/mo"
-	"sort"
 )
 
 const (


### PR DESCRIPTION
konveyor/virt-controller would like to be able to specify a supported access mode when creating storage/disk mappings. This adds an `AccessMode` field to the `StorageResourceMappingItem`, and adds support for mapping the `AccessMode` and `VolumeMode` in the vSphere provider.

`AccessMode` and `VolumeMode` will default respectively to `ReadWriteOnce` and `Filesystem` in the vSphere provider.
The oVirt provider will take the access mode from the mapping if it's set, otherwise it will determine the access mode as it previously did.