### PR TITLE
Fix vSphere VM network mapping bugs and misleading error messages

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -714,10 +714,10 @@ func (r *ReconcileVirtualMachineImport) createVM(provider provider.Provider, ins
 
 	// Create kubevirt VM from source VM:
 	reqLogger.Info("Creating a new VM", "VM.Namespace", vmSpec.Namespace, "VM.Name", vmSpec.Name)
-	if err = r.client.Create(context.TODO(), vmSpec); err != nil && !k8serrors.IsAlreadyExists(err) {
+	if createErr := r.client.Create(context.TODO(), vmSpec); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
 		vmJSON, _ := json.Marshal(vmSpec)
 		reqLogger.Info("VM struct", "VM spec", string(vmJSON))
-		message := fmt.Sprintf("Error while creating virtual machine %s/%s: %s", vmSpec.Namespace, vmSpec.Name, err)
+		message := fmt.Sprintf("Error while creating virtual machine %s/%s: %s", vmSpec.Namespace, vmSpec.Name, createErr)
 		// Update event:
 		r.recorder.Event(instance, corev1.EventTypeWarning, EventVMCreationFailed, message)
 
@@ -736,7 +736,7 @@ func (r *ReconcileVirtualMachineImport) createVM(provider provider.Provider, ins
 		}
 
 		// Reconcile
-		return "", err
+		return "", createErr
 	}
 
 	// Get created VM Name

--- a/pkg/providers/vmware/mapper/mapper_test.go
+++ b/pkg/providers/vmware/mapper/mapper_test.go
@@ -167,6 +167,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 		interfaces := vmSpec.Spec.Template.Spec.Domain.Devices.Interfaces
 		networks := vmSpec.Spec.Template.Spec.Networks
+		networkInterfaceMultiQueue := vmSpec.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
 
 		// interface to be connected to a pod network
 		Expect(interfaces[0].Name).To(Equal(networkNormalizedName))
@@ -175,6 +176,8 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		Expect(interfaces[0].MacAddress).To(Equal(macAddress))
 		Expect(networks[0].Name).To(Equal(networkNormalizedName))
 		Expect(networks[0].Pod).To(Not(BeNil()))
+		Expect(networkInterfaceMultiQueue).ToNot(BeNil())
+		Expect(*networkInterfaceMultiQueue).To(BeTrue())
 	})
 
 	It("should map pod network by name", func() {
@@ -185,6 +188,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 		interfaces := vmSpec.Spec.Template.Spec.Domain.Devices.Interfaces
 		networks := vmSpec.Spec.Template.Spec.Networks
+		networkInterfaceMultiQueue := vmSpec.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
 
 		// interface to be connected to a pod network
 		Expect(interfaces[0].Name).To(Equal(networkNormalizedName))
@@ -193,6 +197,8 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		Expect(interfaces[0].MacAddress).To(Equal(macAddress))
 		Expect(networks[0].Name).To(Equal(networkNormalizedName))
 		Expect(networks[0].Pod).To(Not(BeNil()))
+		Expect(networkInterfaceMultiQueue).ToNot(BeNil())
+		Expect(*networkInterfaceMultiQueue).To(BeTrue())
 	})
 
 	It("should map multus network by network moref", func() {
@@ -204,6 +210,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		interfaces := vmSpec.Spec.Template.Spec.Domain.Devices.Interfaces
 		networks := vmSpec.Spec.Template.Spec.Networks
 		networkMapping := *mappings.NetworkMappings
+		networkInterfaceMultiQueue := vmSpec.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
 
 		// interface to be connected to a multus network
 		Expect(interfaces[0].Name).To(Equal(networkNormalizedName))
@@ -211,6 +218,8 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		Expect(interfaces[0].MacAddress).To(Equal(macAddress))
 		Expect(networks[0].Name).To(Equal(networkNormalizedName))
 		Expect(networks[0].Multus.NetworkName).To(Equal(networkMapping[0].Target.Name))
+		Expect(networkInterfaceMultiQueue).ToNot(BeNil())
+		Expect(*networkInterfaceMultiQueue).To(BeTrue())
 	})
 
 	It("should map multus network by name", func() {
@@ -222,6 +231,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		interfaces := vmSpec.Spec.Template.Spec.Domain.Devices.Interfaces
 		networks := vmSpec.Spec.Template.Spec.Networks
 		networkMapping := *mappings.NetworkMappings
+		networkInterfaceMultiQueue := vmSpec.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
 
 		// interface to be connected to a multus network
 		Expect(interfaces[0].Name).To(Equal(networkNormalizedName))
@@ -229,6 +239,24 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		Expect(interfaces[0].MacAddress).To(Equal(macAddress))
 		Expect(networks[0].Name).To(Equal(networkNormalizedName))
 		Expect(networks[0].Multus.NetworkName).To(Equal(networkMapping[0].Target.Name))
+		Expect(networkInterfaceMultiQueue).ToNot(BeNil())
+		Expect(*networkInterfaceMultiQueue).To(BeTrue())
+	})
+
+	It("should disable NetworkInterfaceMultiQueue when there are no mapped interfaces", func() {
+		mappings := createMinimalMapping()
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
+		Expect(err).To(BeNil())
+
+		interfaces := vmSpec.Spec.Template.Spec.Domain.Devices.Interfaces
+		networks := vmSpec.Spec.Template.Spec.Networks
+		networkInterfaceMultiQueue := vmSpec.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
+
+		Expect(len(interfaces)).To(Equal(0))
+		Expect(len(networks)).To(Equal(0))
+		Expect(networkInterfaceMultiQueue).ToNot(BeNil())
+		Expect(*networkInterfaceMultiQueue).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
* vSphere: Don't add interfaces for unmapped networks
* vSphere: Disable NetworkInterfaceMultiqueue if there are no mapped interfaces
* Controller: Any error from attempting to create a VM in `createVM` was being overwitten by error values from cleanup operations. Preserve the original error so that it can be returned. This prevents a situation where a VM fails to be created and instead of reporting that error, it reports `VirtualMachine.kubevirt.io "" not found`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1892597
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1891440
Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1891508 (fixes the confusing error, but not the underlying problem)