### PR TITLE
Use VM UUID and disk key to name DataVolumes for vSphere VMs

### DIFF
--- a/pkg/providers/vmware/mapper/mapper_test.go
+++ b/pkg/providers/vmware/mapper/mapper_test.go
@@ -41,10 +41,10 @@ var (
 
 	// disks
 	expectedNumDisks  = 2
-	diskId1           = "disk-202-0"
-	diskId2           = "disk-202-1"
-	expectedDiskName1 = "basic-vm-disk-202-0"
-	expectedDiskName2 = "basic-vm-disk-202-1"
+	diskName1         = "disk-202-0"
+	diskName2         = "disk-202-1"
+	expectedDiskName1 = "c39a8d6c-ea37-5c91-8979-334e7e07cab5-203"
+	expectedDiskName2 = "c39a8d6c-ea37-5c91-8979-334e7e07cab5-205"
 
 	volumeModeBlock      = v1.PersistentVolumeBlock
 	volumeModeFilesystem = v1.PersistentVolumeFilesystem
@@ -293,7 +293,7 @@ var _ = Describe("Test mapping disks", func() {
 		mappings.DiskMappings = &[]v1beta1.StorageResourceMappingItem{
 			{
 				Source: v1beta1.Source{
-					Name: &diskId1,
+					Name: &diskName1,
 				},
 				Target: v1beta1.ObjectIdentifier{
 					Name: storageClass,
@@ -304,7 +304,7 @@ var _ = Describe("Test mapping disks", func() {
 			{
 				// using defaults
 				Source: v1beta1.Source{
-					Name: &diskId2,
+					Name: &diskName2,
 				},
 			},
 		}

--- a/tests/vmware/basic_net_vm_import_test.go
+++ b/tests/vmware/basic_net_vm_import_test.go
@@ -103,10 +103,10 @@ func (t *networkedVMImportTest) validateTargetConfiguration(vmName string) *v1.V
 	Expect(disks).To(HaveLen(2))
 	disk0 := disks[0]
 	Expect(disk0.Disk.Bus).To(BeEquivalentTo("virtio"))
-	Expect(disk0.Name).To(BeEquivalentTo("dv-target-vm-disk-202-0"))
+	Expect(disk0.Name).To(BeEquivalentTo("dv-c39a8d6c-ea37-5c91-8979-334e7e07cab5-203"))
 	disk1 := disks[1]
 	Expect(disk1.Disk.Bus).To(BeEquivalentTo("virtio"))
-	Expect(disk1.Name).To(BeEquivalentTo("dv-target-vm-disk-202-1"))
+	Expect(disk1.Name).To(BeEquivalentTo("dv-c39a8d6c-ea37-5c91-8979-334e7e07cab5-205"))
 
 	By("having correct volumes")
 	Expect(spec.Volumes).To(HaveLen(2))

--- a/tests/vmware/basic_vm_import_test.go
+++ b/tests/vmware/basic_vm_import_test.go
@@ -228,7 +228,7 @@ func (t *basicVmImportTest) validateTargetConfiguration(vmName string) *v1.Virtu
 	Expect(disks).To(HaveLen(1))
 	disk0 := disks[0]
 	Expect(disk0.Disk.Bus).To(BeEquivalentTo("virtio"))
-	Expect(disk0.Name).To(BeEquivalentTo("dv-target-vm-disk-202-0"))
+	Expect(disk0.Name).To(BeEquivalentTo("dv-f7c371d6-2003-5a48-9859-3bc9a8b08908-204"))
 
 	By("having correct volumes")
 	Expect(spec.Volumes).To(HaveLen(1))


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1898840

Signed-off-by: Sam Lucidi <slucidi@redhat.com>