### PR TITLE
Validate the target VM name and ensure uniqueness

### DIFF
--- a/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
@@ -194,6 +194,9 @@ const (
 
 	// InvalidTargetVMName represents the target VM name being an invalid k8s name
 	InvalidTargetVMName ValidConditionReason = "InvalidTargetVMName"
+
+	// DuplicateTargetVMName
+	DuplicateTargetVMName ValidConditionReason = "DuplicateTargetVMName"
 )
 
 // MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import

--- a/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
@@ -191,6 +191,9 @@ const (
 
 	// ValidationReportedWarnings represents the existence of warnings related to resource mapping validation
 	ValidationReportedWarnings ValidConditionReason = "ValidationReportedWarnings"
+
+	// InvalidTargetVMName represents the target VM name being an invalid k8s name
+	InvalidTargetVMName ValidConditionReason = "InvalidTargetVMName"
 )
 
 // MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -266,12 +266,72 @@ var _ = Describe("Reconcile steps", func() {
 
 	})
 
+	Describe("validate name", func() {
+		It("should fail with a target VM name that is provided but empty: ", func() {
+			emptyName := ""
+			instance.Spec.TargetVMName = &emptyName
+			err := validateName(instance, "ignored")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a source VM name that is empty if no target VM is provided: ", func() {
+			emptyName := ""
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, emptyName)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a target VM name that contains invalid characters: ", func() {
+			invalidName := "#$%^&*()"
+			instance.Spec.TargetVMName = &invalidName
+			err := validateName(instance, "ignored")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a source VM name that contains invalid characters: ", func() {
+			invalidName := "#$%^&*()"
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, invalidName)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a target VM name that is longer than 63 characters: ", func() {
+			longName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl"
+			instance.Spec.TargetVMName = &longName
+			err := validateName(instance, "ignored")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a source VM name that is longer than 63 characters: ", func() {
+			longName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl"
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, longName)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should succeed with a target VM name that is 63 characters long: ", func() {
+			name := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk"
+			instance.Spec.TargetVMName = &name
+			err := validateName(instance, "ignored")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed with a source VM name that is 63 characters long: ", func() {
+			name := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk"
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Describe("validate step", func() {
 		BeforeEach(func() {
 			instance.Spec.Source.Ovirt = &v2vv1.VirtualMachineImportOvirtSourceSpec{}
 			instance.Spec.ResourceMapping = &v2vv1.ObjectIdentifier{}
 			instance.Name = "test"
 			instance.Namespace = "test"
+			targetVMName := "valid-target-name"
+			instance.Spec.TargetVMName = &targetVMName
 			mock = &mockProvider{}
 		})
 


### PR DESCRIPTION
Validates the format of the targetVMName or the source VM name if the target name was not provided. Also ensures that there is not already a VirtualMachine in the namespace with that name.

Removing the normalization can be a follow up, but it should be harmless for now since any names that would be normalized should be caught by the validation.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1894825