### PR TITLE
Validate the target VM name and ensure uniqueness

### DIFF
--- a/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
@@ -194,6 +194,9 @@ const (
 
 	// InvalidTargetVMName represents the target VM name being an invalid k8s name
 	InvalidTargetVMName ValidConditionReason = "InvalidTargetVMName"
+
+	// DuplicateTargetVMName
+	DuplicateTargetVMName ValidConditionReason = "DuplicateTargetVMName"
 )
 
 // MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import

--- a/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
+++ b/pkg/apis/v2v/v1beta1/virtualmachineimport_types.go
@@ -191,6 +191,9 @@ const (
 
 	// ValidationReportedWarnings represents the existence of warnings related to resource mapping validation
 	ValidationReportedWarnings ValidConditionReason = "ValidationReportedWarnings"
+
+	// InvalidTargetVMName represents the target VM name being an invalid k8s name
+	InvalidTargetVMName ValidConditionReason = "InvalidTargetVMName"
 )
 
 // MappingRulesVerifiedReason defines the reasons for the MappingRulesVerified condition of VM import

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -1365,6 +1365,23 @@ func validateName(instance *v2vv1.VirtualMachineImport, sourceName string) error
 	return nil
 }
 
+func (r *ReconcileVirtualMachineImport) validateUniqueness(instance *v2vv1.VirtualMachineImport, sourceName string) (bool, error) {
+	var name string
+	if instance.Spec.TargetVMName != nil {
+		name = *instance.Spec.TargetVMName
+	} else {
+		name = sourceName
+	}
+
+	namespacedName := types.NamespacedName{Namespace: instance.Namespace, Name: name}
+	err := r.client.Get(context.TODO(), namespacedName, &kubevirtv1.VirtualMachine{})
+	if err != nil && k8serrors.IsNotFound(err) {
+		return true, nil
+	}
+
+	return false, err
+}
+
 func (r *ReconcileVirtualMachineImport) validate(instance *v2vv1.VirtualMachineImport, provider provider.Provider) (bool, error) {
 	logger := log.WithValues("Request.Namespace", instance.Namespace, "Request.Name", instance.Name)
 	if shouldInvoke(&instance.Status) {
@@ -1378,6 +1395,16 @@ func (r *ReconcileVirtualMachineImport) validate(instance *v2vv1.VirtualMachineI
 		if err != nil {
 			invalidNameCond := conditions.NewCondition(v2vv1.Valid, string(v2vv1.InvalidTargetVMName), err.Error(), corev1.ConditionFalse)
 			err := r.upsertStatusConditions(types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, invalidNameCond)
+			return false, err
+		}
+
+		unique, err := r.validateUniqueness(instance, vmName)
+		if err != nil {
+			return false, err
+		}
+		if !unique {
+			duplicateNameCond := conditions.NewCondition(v2vv1.Valid, string(v2vv1.DuplicateTargetVMName), "Virtual machine already exists in target namespace", corev1.ConditionFalse)
+			err := r.upsertStatusConditions(types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, duplicateNameCond)
 			return false, err
 		}
 

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -324,6 +324,39 @@ var _ = Describe("Reconcile steps", func() {
 		})
 	})
 
+	Describe("validate uniqueness", func() {
+		BeforeEach(func() {
+			instance.Spec.Source.Ovirt = &v2vv1.VirtualMachineImportOvirtSourceSpec{}
+			instance.Name = "test"
+			instance.Namespace = "test"
+			mock = &mockProvider{}
+		})
+
+		It("should fail if the target VM already exists in the namespace", func() {
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				switch obj.(type) {
+				case *kubevirtv1.VirtualMachine:
+					obj.(*kubevirtv1.VirtualMachine).Spec = kubevirtv1.VirtualMachineSpec{}
+				}
+				return nil
+			}
+
+			unique, err := reconciler.validateUniqueness(instance, "vm-exists")
+			Expect(unique).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed if the target VM doesn't already exists in the namespace", func() {
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				return errors.NewNotFound(schema.GroupResource{}, "")
+			}
+
+			unique, err := reconciler.validateUniqueness(instance, "not-found")
+			Expect(unique).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Describe("validate step", func() {
 		BeforeEach(func() {
 			instance.Spec.Source.Ovirt = &v2vv1.VirtualMachineImportOvirtSourceSpec{}
@@ -333,6 +366,21 @@ var _ = Describe("Reconcile steps", func() {
 			targetVMName := "valid-target-name"
 			instance.Spec.TargetVMName = &targetVMName
 			mock = &mockProvider{}
+
+			get = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				switch obj.(type) {
+				case *v2vv1.VirtualMachineImport:
+					obj.(*v2vv1.VirtualMachineImport).Spec = v2vv1.VirtualMachineImportSpec{}
+				case *v2vv1.ResourceMapping:
+					obj.(*v2vv1.ResourceMapping).Spec = v2vv1.ResourceMappingSpec{}
+				case *corev1.Secret:
+					obj.(*corev1.Secret).Data = map[string][]byte{"ovirt": getSecret()}
+				case *kubevirtv1.VirtualMachine:
+					return errors.NewNotFound(schema.GroupResource{}, "")
+
+				}
+				return nil
+			}
 		})
 
 		It("should succeed to validate: ", func() {
@@ -360,8 +408,10 @@ var _ = Describe("Reconcile steps", func() {
 					return fmt.Errorf("Let's make it fail if it tries to validate")
 				case *v2vv1.ResourceMapping:
 					obj.(*v2vv1.ResourceMapping).Spec = v2vv1.ResourceMappingSpec{}
-				default:
+				case *corev1.Secret:
 					obj.(*corev1.Secret).Data = map[string][]byte{"ovirt": getSecret()}
+				case *kubevirtv1.VirtualMachine:
+					return errors.NewNotFound(schema.GroupResource{}, "")
 				}
 				return nil
 			}
@@ -390,8 +440,10 @@ var _ = Describe("Reconcile steps", func() {
 					return fmt.Errorf("Not found")
 				case *v2vv1.ResourceMapping:
 					obj.(*v2vv1.ResourceMapping).Spec = v2vv1.ResourceMappingSpec{}
-				default:
+				case *corev1.Secret:
 					obj.(*corev1.Secret).Data = map[string][]byte{"ovirt": getSecret()}
+				case *kubevirtv1.VirtualMachine:
+					return errors.NewNotFound(schema.GroupResource{}, "")
 				}
 				return nil
 			}
@@ -1467,6 +1519,8 @@ var _ = Describe("Reconcile steps", func() {
 					}
 				case *corev1.Secret:
 					obj.(*corev1.Secret).Data = map[string][]byte{"ovirt": getSecret()}
+				case *kubevirtv1.VirtualMachine:
+					return errors.NewNotFound(schema.GroupResource{}, "")
 				}
 				return nil
 			}

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -266,12 +266,72 @@ var _ = Describe("Reconcile steps", func() {
 
 	})
 
+	Describe("validate name", func() {
+		It("should fail with a target VM name that is provided but empty: ", func() {
+			emptyName := ""
+			instance.Spec.TargetVMName = &emptyName
+			err := validateName(instance, "ignored")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a source VM name that is empty if no target VM is provided: ", func() {
+			emptyName := ""
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, emptyName)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a target VM name that contains invalid characters: ", func() {
+			invalidName := "#$%^&*()"
+			instance.Spec.TargetVMName = &invalidName
+			err := validateName(instance, "ignored")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a source VM name that contains invalid characters: ", func() {
+			invalidName := "#$%^&*()"
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, invalidName)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a target VM name that is longer than 63 characters: ", func() {
+			longName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl"
+			instance.Spec.TargetVMName = &longName
+			err := validateName(instance, "ignored")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail with a source VM name that is longer than 63 characters: ", func() {
+			longName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl"
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, longName)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should succeed with a target VM name that is 63 characters long: ", func() {
+			name := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk"
+			instance.Spec.TargetVMName = &name
+			err := validateName(instance, "ignored")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed with a source VM name that is 63 characters long: ", func() {
+			name := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk"
+			instance.Spec.TargetVMName = nil
+			err := validateName(instance, name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Describe("validate step", func() {
 		BeforeEach(func() {
 			instance.Spec.Source.Ovirt = &v2vv1.VirtualMachineImportOvirtSourceSpec{}
 			instance.Spec.ResourceMapping = &v2vv1.ObjectIdentifier{}
 			instance.Name = "test"
 			instance.Namespace = "test"
+			targetVMName := "valid-target-name"
+			instance.Spec.TargetVMName = &targetVMName
 			mock = &mockProvider{}
 		})
 

--- a/tests/ovirt/multiple_vms_import_test.go
+++ b/tests/ovirt/multiple_vms_import_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Multiple VMs import ", func() {
 			By("Importing second VM")
 			created, err := test.triggerVMImport(vmID, namespace, vmName, test.secret.Name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(created).To(BeSuccessful(f))
+			Expect(created).To(HaveValidationFailure(f, string(v2vv1.DuplicateTargetVMName)))
 
 			By("Having only one VM imported in the end")
 			vms := &v1.VirtualMachineList{}


### PR DESCRIPTION
Validates the format of the targetVMName or the source VM name if the target name was not provided. Also ensures that there is not already a VirtualMachine in the namespace with that name.

Removing the normalization can be a follow up, but it should be harmless for now since any names that would be normalized should be caught by the validation.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1894825