### PR TITLE
oVirt mapper: use 'scsi' bus for disks with the 'virtio_scsi' type

### DIFF
--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -46,6 +46,9 @@ var (
 	DefaultVolumeMode = corev1.PersistentVolumeFilesystem
 )
 
+// DiskInterfaceModelMapping defines mapping of disk interface models between oVirt and kubevirt domains
+var DiskInterfaceModelMapping = map[string]string{"sata": "sata", "virtio_scsi": "scsi", "virtio": "virtio"}
+
 // BiosTypeMapping defines mapping of BIOS types between oVirt and kubevirt domains
 var BiosTypeMapping = map[string]*kubevirtv1.Bootloader{
 	"q35_sea_bios":    {BIOS: &kubevirtv1.BIOS{}},
@@ -211,7 +214,7 @@ func (o *OvirtMapper) MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVo
 		Name: name,
 		DiskDevice: kubevirtv1.DiskDevice{
 			Disk: &kubevirtv1.DiskTarget{
-				Bus: o.mapDiskInterface(iface),
+				Bus: DiskInterfaceModelMapping[string(iface)],
 			},
 		},
 	}
@@ -222,13 +225,6 @@ func (o *OvirtMapper) MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVo
 
 	vmSpec.Spec.Template.Spec.Volumes = append(vmSpec.Spec.Template.Spec.Volumes, volume)
 	vmSpec.Spec.Template.Spec.Domain.Devices.Disks = append(vmSpec.Spec.Template.Spec.Domain.Devices.Disks, disk)
-}
-
-func (o *OvirtMapper) mapDiskInterface(iface ovirtsdk.DiskInterface) string {
-	if iface == ovirtsdk.DISKINTERFACE_VIRTIO_SCSI {
-		return string(ovirtsdk.DISKINTERFACE_VIRTIO)
-	}
-	return string(iface)
 }
 
 // If the mapping specifies the access mode return that, otherwise determine the access mode

--- a/pkg/providers/ovirt/validation/validators/storage-validator.go
+++ b/pkg/providers/ovirt/validation/validators/storage-validator.go
@@ -2,13 +2,11 @@ package validators
 
 import (
 	"fmt"
+	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/mapper"
 
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
 	ovirtsdk "github.com/ovirt/go-ovirt"
 )
-
-// DiskInterfaceModelMapping defines mapping of disk interface models between oVirt and kubevirt domains
-var DiskInterfaceModelMapping = map[string]string{"sata": "sata", "virtio_scsi": "virtio", "virtio": "virtio"}
 
 // diskInterfaceOwner defines means of getting interface of a storage entity
 type diskInterfaceOwner interface {
@@ -124,10 +122,10 @@ func isValidDiskInterface(disk *ovirtsdk.Disk, diskID string) (ValidationFailure
 
 func isValidStorageInterface(diskAttachment diskInterfaceOwner, ownerID string, checkID CheckID) (ValidationFailure, bool) {
 	if iface, ok := diskAttachment.Interface(); ok {
-		if _, found := DiskInterfaceModelMapping[string(iface)]; !found {
+		if _, found := mapper.DiskInterfaceModelMapping[string(iface)]; !found {
 			return ValidationFailure{
 				ID:      checkID,
-				Message: fmt.Sprintf("%s %s uses interface %v. Allowed values: %v", checkID, ownerID, iface, utils.GetMapKeys(DiskInterfaceModelMapping)),
+				Message: fmt.Sprintf("%s %s uses interface %v. Allowed values: %v", checkID, ownerID, iface, utils.GetMapKeys(mapper.DiskInterfaceModelMapping)),
 			}, false
 		}
 	}

--- a/tests/ovirt/multiple_vms_import_test.go
+++ b/tests/ovirt/multiple_vms_import_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/client-go/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type multipleVmsImportTest struct {
@@ -104,7 +105,7 @@ var _ = Describe("Multiple VMs import ", func() {
 
 			By("Having only one VM imported in the end")
 			vms := &v1.VirtualMachineList{}
-			err = f.Client.List(context.TODO(), vms)
+			err = f.Client.List(context.TODO(), vms, client.InNamespace(namespace))
 			if err != nil {
 				Fail(err.Error())
 			}


### PR DESCRIPTION
This sets the destination disk bus type to `scsi` when oVirt reports that the source disk is `virtio_scsi`. Kubevirt does not appear to accept `virtio_scsi` as a bus type, but it looks like `scsi` should work.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1903585. I don't have an oVirt setup to test against, and since the issue is Windows booting in repair mode I don't see any way to create a functional test.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>