### PR TITLE
Update Network Mapping validation for duplicates

### DIFF
--- a/pkg/providers/ovirt/validation/validators/definitions.go
+++ b/pkg/providers/ovirt/validation/validators/definitions.go
@@ -127,6 +127,8 @@ const (
 	NetworkConfig = CheckID("network.config")
 	// NetworkMultiplePodTargetsID defines an ID of a check verifying that there is not more than one network mapped to a pod network
 	NetworkMultiplePodTargetsID = CheckID("network.pod.multiple")
+	// NetworkSourceDuplicateID defines an ID of a check verifying that there are no duplicated keys in source networks
+	NetworkSourceDuplicateID = CheckID("network.source.duplicate")
 	// StorageTargetID defines an ID of a check verifying existence of target storage class
 	StorageTargetID = CheckID("storage.target")
 	// DiskTargetID defines an ID of a check verifying existence of target storage class

--- a/pkg/providers/ovirt/validation/validators/network-mapping-validator.go
+++ b/pkg/providers/ovirt/validation/validators/network-mapping-validator.go
@@ -44,6 +44,30 @@ func (v *NetworkMappingValidator) ValidateNetworkMapping(nics []*ovirtsdk.Nic, m
 		return failures
 	}
 
+	// Validate non-duplicates in source networks mapping for both Name and ID
+	usedNames := make(map[string]bool)
+	usedIDs := make(map[string]bool)
+	for _, mapp := range *mapping {
+		if mapp.Source.ID != nil {
+			if val, _ := usedIDs[*mapp.Source.ID]; val {
+				failures = append(failures, ValidationFailure{
+					ID:      NetworkSourceDuplicateID,
+					Message: fmt.Sprintf("There are duplicate source network entries for ID: %v ", *mapp.Source.Name),
+				})
+			}
+			usedIDs[*mapp.Source.ID] = true
+		}
+		if mapp.Source.Name != nil {
+			if val, _ := usedNames[*mapp.Source.Name]; val {
+				failures = append(failures, ValidationFailure{
+					ID:      NetworkSourceDuplicateID,
+					Message: fmt.Sprintf("There are duplicate source network entries for name: %v ", *mapp.Source.Name),
+				})
+			}
+			usedNames[*mapp.Source.Name] = true
+		}
+	}
+
 	// Map source id and name to ResourceMappingItem
 	mapByID, mapByName := utils.IndexNetworkByIDAndName(mapping)
 

--- a/pkg/providers/ovirt/validation/validators/network-mapping-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/network-mapping-validator_test.go
@@ -373,6 +373,37 @@ var _ = Describe("Validating Network mapping", func() {
 
 		Expect(failures).To(BeEmpty())
 	})
+	It("should reject duplicate mapping for single source nic", func() {
+		nics := []*ovirtsdk.Nic{
+			createNic(&networkName, &vnicProfileName, &vnicProfileID, false),
+		}
+
+		mapping := []v2vv1.NetworkResourceMappingItem{
+			{
+				Source: v2vv1.Source{
+					Name: &srcNetMappingName,
+				},
+				Target: v2vv1.ObjectIdentifier{
+					Name: "pod",
+				},
+				Type: &podType,
+			},
+			{
+				Source: v2vv1.Source{
+					Name: &srcNetMappingName,
+				},
+				Target: v2vv1.ObjectIdentifier{
+					Name: "ovn-kubernetes1",
+				},
+				Type: &multusType,
+			},
+		}
+
+		failures := validator.ValidateNetworkMapping(nics, &mapping, namespace)
+
+		Expect(failures).To(HaveLen(1))
+		Expect(failures[0].ID).To(Equal(validators.NetworkSourceDuplicateID))
+	})
 	It("should reject mapping of two nics of the same vnic profile to a pod network", func() {
 		nics := []*ovirtsdk.Nic{
 			createNic(&networkName, &vnicProfileName, &vnicProfileID, false),


### PR DESCRIPTION
Network mapping should not allow the same source network more than once. Updating network
validation code to check for duplicate Name or ID in Network Source Mapping.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1885153