### PR TITLE
Base Dockerfiles on ubi/go-toolset:1.14.12

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -1,17 +1,17 @@
-FROM golang:1.13 AS builder
-WORKDIR /src/vm-import-operator/
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 AS builder
+WORKDIR /opt/app-root/src/vm-import-operator/
 COPY . .
 ENV GOFLAGS=-mod=vendor
 ENV GO111MODULE=on
-RUN	CGO_ENABLED=0 GOOS=linux go build -o /vm-import-controller cmd/manager/main.go
+RUN	CGO_ENABLED=0 GOOS=linux go build -o /opt/app-root/vm-import-controller cmd/manager/main.go
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV CONTROLLER=/usr/local/bin/vm-import-controller \
     USER_UID=1001 \
     USER_NAME=vm-import-controller
 
 # install controller binary
-COPY --from=builder /vm-import-controller ${CONTROLLER}
+COPY --from=builder /opt/app-root/vm-import-controller ${CONTROLLER}
 # Controller needs timezone data for VM validation
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY build/controller/bin /usr/local/bin

--- a/build/imageio-init/Dockerfile
+++ b/build/imageio-init/Dockerfile
@@ -1,14 +1,14 @@
-FROM golang:1.12 AS builder
-WORKDIR /src/vm-import-operator/
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 AS builder
+WORKDIR /opt/app-root/src/vm-import-operator/
 COPY . .
 ENV GOFLAGS=-mod=vendor
 ENV GO111MODULE=on
-RUN CGO_ENABLED=0 GOOS=linux go build -o /imageio-init tools/imageio-init/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o /opt/app-root/imageio-init tools/imageio-init/main.go
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 # install controller binary
-COPY --from=builder /imageio-init /imageio-init
-COPY --from=builder /src/vm-import-operator/tools/imageio-init/entrypoint.sh /entrypoint.sh
+COPY --from=builder /opt/app-root/imageio-init /imageio-init
+COPY --from=builder /opt/app-root/src/vm-import-operator/tools/imageio-init/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.13 AS builder
-WORKDIR /src/vm-import-operator/
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 AS builder
+WORKDIR /opt/app-root/src/vm-import-operator/
 COPY . .
 ENV GOFLAGS=-mod=vendor
 ENV GO111MODULE=on
-RUN CGO_ENABLED=0 GOOS=linux go build -o /csv-generator tools/csv-generator/csv-generator.go
-RUN CGO_ENABLED=0 GOOS=linux go build -o /vm-import-operator cmd/operator/operator.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o /opt/app-root/csv-generator tools/csv-generator/csv-generator.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o /opt/app-root/vm-import-operator cmd/operator/operator.go
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/vm-import-operator \
     USER_UID=1001 \
@@ -14,8 +14,8 @@ ENV OPERATOR=/usr/local/bin/vm-import-operator \
     CSV_GENERATOR=/usr/bin/csv-generator
 
 # install operator binary
-COPY --from=builder /vm-import-operator ${OPERATOR}
-COPY --from=builder /csv-generator ${CSV_GENERATOR}
+COPY --from=builder /opt/app-root/vm-import-operator ${OPERATOR}
+COPY --from=builder /opt/app-root/csv-generator ${CSV_GENERATOR}
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -25,7 +25,7 @@ function install_kubevirt {
 
 # Install golang to run generate manifests
 function ensure_golang {
-    GOVERSION='go1.14.2.linux-amd64.tar.gz'
+    GOVERSION='go1.14.12.linux-amd64.tar.gz'
     if [[ "$(go version 2>&1)" =~ "not found" ]]; then
         wget -q https://dl.google.com/go/${GOVERSION}
         tar -C /usr/local -xzf ${GOVERSION}


### PR DESCRIPTION
This should ensure that the images are built with a recent enough version of Go to avoid [CVE-2020-28362](https://nvd.nist.gov/vuln/detail/CVE-2020-28362).

Signed-off-by: Sam Lucidi <slucidi@redhat.com>