### PR TITLE
Stop Using Deprecated Packages

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 // Change below variables to serve metrics on different host or port.

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -16,7 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var log = logf.Log.WithName("cmd")
@@ -28,7 +29,7 @@ func printVersion() {
 
 func main() {
 	flag.Parse()
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(zap.New(zap.UseDevMode(false)))
 
 	printVersion()
 

--- a/pkg/apis/v2v/v1alpha1/register.go
+++ b/pkg/apis/v2v/v1alpha1/register.go
@@ -7,7 +7,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (

--- a/pkg/apis/v2v/v1beta1/register.go
+++ b/pkg/apis/v2v/v1beta1/register.go
@@ -7,7 +7,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 

--- a/pkg/operator/controller/controller_suite_test.go
+++ b/pkg/operator/controller/controller_suite_test.go
@@ -12,7 +12,8 @@ import (
 
 	resources "github.com/kubevirt/vm-import-operator/pkg/operator/resources/operator"
 	"k8s.io/client-go/rest"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestOperator(t *testing.T) {
@@ -26,7 +27,7 @@ var cfg *rest.Config
 var crd = resources.CreateVMImportConfig()
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(logf.ZapLoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.UseDevMode(false), zap.WriteTo(GinkgoWriter)))
 
 	env := &envtest.Environment{}
 


### PR DESCRIPTION
sigs.k8s.io/controller-runtime/pkg/runtime/* packages are deprecated, and were moved to new pathes

Trying to upgrade sigs.k8s.io/controller-runtime to version v0.7.0 in HCO created a conflict because in v0.7.0 the deprecated packages were removed and cannot be used.

This PR replaces the deprecated packages with their new pathes.

```release-notes
NONE
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>