### PR TITLE
Mount block devices properly on the virt-v2v container

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -1178,10 +1178,12 @@ var _ = Describe("Reconcile steps", func() {
 			prov   *mockProvider
 			vmName types.NamespacedName
 			pod    *corev1.Pod
+			mapper *mockMapper
 		)
 
 		BeforeEach(func() {
 			prov = &mockProvider{}
+			mapper = &mockMapper{}
 			vmName = types.NamespacedName{Name: "test", Namespace: "default"}
 
 			pod = &corev1.Pod{
@@ -1240,7 +1242,7 @@ var _ = Describe("Reconcile steps", func() {
 		It("should return false with no error when the pod is pending", func() {
 			pod.Status.Phase = corev1.PodPending
 
-			done, err := reconciler.convertGuest(prov, instance, vmName)
+			done, err := reconciler.convertGuest(prov, instance, mapper, vmName)
 			Expect(err).To(BeNil())
 			Expect(done).To(BeFalse())
 		})
@@ -1248,7 +1250,7 @@ var _ = Describe("Reconcile steps", func() {
 		It("should return false with no error when the pod is running", func() {
 			pod.Status.Phase = corev1.PodRunning
 
-			done, err := reconciler.convertGuest(prov, instance, vmName)
+			done, err := reconciler.convertGuest(prov, instance, mapper, vmName)
 			Expect(err).To(BeNil())
 			Expect(done).To(BeFalse())
 		})
@@ -1256,7 +1258,7 @@ var _ = Describe("Reconcile steps", func() {
 		It("should return false with no error when the pod is failed", func() {
 			pod.Status.Phase = corev1.PodFailed
 
-			done, err := reconciler.convertGuest(prov, instance, vmName)
+			done, err := reconciler.convertGuest(prov, instance, mapper, vmName)
 			Expect(err).To(BeNil())
 			Expect(done).To(BeFalse())
 		})
@@ -1264,7 +1266,7 @@ var _ = Describe("Reconcile steps", func() {
 		It("should return true with no error when the pod is successful", func() {
 			pod.Status.Phase = corev1.PodSucceeded
 
-			done, err := reconciler.convertGuest(prov, instance, vmName)
+			done, err := reconciler.convertGuest(prov, instance, mapper, vmName)
 			Expect(err).To(BeNil())
 			Expect(done).To(BeTrue())
 		})
@@ -2053,7 +2055,7 @@ func (p *mockProvider) GetGuestConversionPod() (*corev1.Pod, error) {
 	return getGuestConversionPod()
 }
 
-func (p *mockProvider) LaunchGuestConversionPod(_ *kubevirtv1.VirtualMachine) (*corev1.Pod, error) {
+func (p *mockProvider) LaunchGuestConversionPod(_ *kubevirtv1.VirtualMachine, _ map[string]cdiv1.DataVolume) (*corev1.Pod, error) {
 	return launchGuestConversionPod()
 }
 

--- a/pkg/guestconversion/guestconversion.go
+++ b/pkg/guestconversion/guestconversion.go
@@ -2,6 +2,7 @@ package guestconversion
 
 import (
 	"fmt"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"os"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
@@ -22,11 +23,11 @@ var (
 // MakeGuestConversionPodSpec creates a pod spec for a virt-v2v pod,
 // containing a volume and a mount for each volume on the VM, as well
 // as a volume and mount for the config map containing the libvirt domain XML.
-func MakeGuestConversionPodSpec(vmSpec *v1.VirtualMachine, libvirtConfigMap *corev1.ConfigMap) *corev1.Pod {
+func MakeGuestConversionPodSpec(vmSpec *v1.VirtualMachine, dataVolumes map[string]cdiv1.DataVolume, libvirtConfigMap *corev1.ConfigMap) *corev1.Pod {
 	// this is the fsGroup that the CDI importer pod uses
 	fsGroup := common.QemuSubGid
 
-	volumes, volumeMounts := makePodVolumeMounts(vmSpec, libvirtConfigMap)
+	volumes, volumeMounts, volumeDevices := makePodVolumeMounts(vmSpec, dataVolumes, libvirtConfigMap)
 
 	return &corev1.Pod{
 		Spec: corev1.PodSpec{
@@ -39,6 +40,7 @@ func MakeGuestConversionPodSpec(vmSpec *v1.VirtualMachine, libvirtConfigMap *cor
 					Name:            "virt-v2v",
 					Image:           virtV2vImage,
 					VolumeMounts:    volumeMounts,
+					VolumeDevices:   volumeDevices,
 					ImagePullPolicy: imagePullPolicy,
 					// Request access to /dev/kvm via Kubevirt's Device Manager
 					Resources: corev1.ResourceRequirements{
@@ -57,28 +59,47 @@ func MakeGuestConversionPodSpec(vmSpec *v1.VirtualMachine, libvirtConfigMap *cor
 	}
 }
 
-func makePodVolumeMounts(vmSpec *v1.VirtualMachine, libvirtConfigMap *corev1.ConfigMap) ([]corev1.Volume, []corev1.VolumeMount) {
+func makePodVolumeMounts(vmSpec *v1.VirtualMachine, dataVolumes map[string]cdiv1.DataVolume, libvirtConfigMap *corev1.ConfigMap) ([]corev1.Volume, []corev1.VolumeMount, []corev1.VolumeDevice) {
 	volumes := make([]corev1.Volume, 0)
 	volumeMounts := make([]corev1.VolumeMount, 0)
+	volumeDevices := make([]corev1.VolumeDevice, 0)
+
 	// add volumes and mounts for each of the VM's disks.
 	// the virt-v2v pod expects to see the disks mounted at /mnt/disks/diskX
-	for i, dataVolume := range vmSpec.Spec.Template.Spec.Volumes {
+	for i, v := range vmSpec.Spec.Template.Spec.Volumes {
+		var volumeMode corev1.PersistentVolumeMode
+		dv, ok := dataVolumes[v.DataVolume.Name]
+		if ok && dv.Spec.PVC != nil && dv.Spec.PVC.VolumeMode != nil {
+			volumeMode = *dv.Spec.PVC.VolumeMode
+		} else {
+			// default to Filesystem if a volume mode is not specified
+			volumeMode = corev1.PersistentVolumeFilesystem
+		}
+
 		vol := corev1.Volume{
-			Name: dataVolume.DataVolume.Name,
+			Name: dv.Name,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: dataVolume.DataVolume.Name,
+					ClaimName: dv.Name,
 					ReadOnly:  false,
 				},
 			},
 		}
 		volumes = append(volumes, vol)
 
-		volMount := corev1.VolumeMount{
-			Name:      dataVolume.DataVolume.Name,
-			MountPath: fmt.Sprintf("/mnt/disks/disk%v", i),
+		if volumeMode == corev1.PersistentVolumeBlock {
+			volDevice := corev1.VolumeDevice{
+				Name:       v.DataVolume.Name,
+				DevicePath: fmt.Sprintf("/dev/block%v", i),
+			}
+			volumeDevices = append(volumeDevices, volDevice)
+		} else {
+			volMount := corev1.VolumeMount{
+				Name:      v.DataVolume.Name,
+				MountPath: fmt.Sprintf("/mnt/disks/disk%v", i),
+			}
+			volumeMounts = append(volumeMounts, volMount)
 		}
-		volumeMounts = append(volumeMounts, volMount)
 	}
 
 	// add volume and mount for the libvirt domain xml config map.
@@ -97,28 +118,37 @@ func makePodVolumeMounts(vmSpec *v1.VirtualMachine, libvirtConfigMap *corev1.Con
 		Name:      configMapVolumeName,
 		MountPath: "/mnt/v2v",
 	})
-	return volumes, volumeMounts
+	return volumes, volumeMounts, volumeDevices
 }
 
 // MakeLibvirtDomain makes a minimal libvirt domain for a VM to be used by the guest conversion pod
-func MakeLibvirtDomain(vmSpec *v1.VirtualMachine) *libvirtxml.Domain {
+func MakeLibvirtDomain(vmSpec *v1.VirtualMachine, dataVolumes map[string]cdiv1.DataVolume) *libvirtxml.Domain {
 	// virt-v2v needs a very minimal libvirt domain XML file to be provided
 	// with the locations of each of the disks on the VM that is to be converted.
 	libvirtDisks := make([]libvirtxml.DomainDisk, 0)
-	for i := range vmSpec.Spec.Template.Spec.Volumes {
+	for i, vol := range vmSpec.Spec.Template.Spec.Volumes {
+		diskSource := libvirtxml.DomainDiskSource{}
+
+		dv := dataVolumes[vol.DataVolume.Name]
+		if *dv.Spec.PVC.VolumeMode == corev1.PersistentVolumeBlock {
+			diskSource.Block = &libvirtxml.DomainDiskSourceBlock{
+				Dev: fmt.Sprintf("/dev/block%v", i),
+			}
+		} else {
+			diskSource.File = &libvirtxml.DomainDiskSourceFile{
+				// the location where the disk images will be found on
+				// the virt-v2v pod. See also makePodVolumeMounts.
+				File: fmt.Sprintf("/mnt/disks/disk%v/disk.img", i),
+			}
+		}
+
 		libvirtDisk := libvirtxml.DomainDisk{
 			Device: "disk",
 			Driver: &libvirtxml.DomainDiskDriver{
 				Name: "qemu",
 				Type: "raw",
 			},
-			Source: &libvirtxml.DomainDiskSource{
-				File: &libvirtxml.DomainDiskSourceFile{
-					// the location where the disk images will be found on
-					// the virt-v2v pod. See also makePodVolumeMounts.
-					File: fmt.Sprintf("/mnt/disks/disk%v/disk.img", i),
-				},
-			},
+			Source: &diskSource,
 			Target: &libvirtxml.DomainDiskTarget{
 				Dev: "hd" + string(rune('a'+i)),
 				Bus: "virtio",

--- a/pkg/guestconversion/guestconversion_test.go
+++ b/pkg/guestconversion/guestconversion_test.go
@@ -7,15 +7,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 )
 
 var _ = Describe("GuestConversion", func() {
+	volumeModeBlock := v1.PersistentVolumeBlock
+	volumeModeFilesystem := v1.PersistentVolumeFilesystem
 
 	Describe("MakeGuestConversionPodSpec", func() {
 
 		var configMap *v1.ConfigMap
 		var vmSpec *kubevirtv1.VirtualMachine
 		var volumes []kubevirtv1.Volume
+		var dataVolumes map[string]cdiv1.DataVolume
 
 		BeforeEach(func() {
 			configMap = &v1.ConfigMap{
@@ -33,10 +37,31 @@ var _ = Describe("GuestConversion", func() {
 					},
 				},
 			}
+
+			dataVolumes = map[string]cdiv1.DataVolume{
+				"dv-1": {
+					ObjectMeta: metav1.ObjectMeta{Name: "dv-1"},
+					Spec: cdiv1.DataVolumeSpec{
+						PVC: &v1.PersistentVolumeClaimSpec{VolumeMode: &volumeModeFilesystem},
+					},
+				},
+				"dv-2": {
+					ObjectMeta: metav1.ObjectMeta{Name: "dv-2"},
+					Spec: cdiv1.DataVolumeSpec{
+						PVC: &v1.PersistentVolumeClaimSpec{VolumeMode: &volumeModeFilesystem},
+					},
+				},
+				"dv-block": {
+					ObjectMeta: metav1.ObjectMeta{Name: "dv-block"},
+					Spec: cdiv1.DataVolumeSpec{
+						PVC: &v1.PersistentVolumeClaimSpec{VolumeMode: &volumeModeBlock},
+					},
+				},
+			}
 		})
 
 		It("should create a volume and mount for the libvirt domain config map", func() {
-			pod := MakeGuestConversionPodSpec(vmSpec, configMap)
+			pod := MakeGuestConversionPodSpec(vmSpec, dataVolumes, configMap)
 			Expect(len(pod.Spec.Volumes)).To(Equal(1))
 			Expect(pod.Spec.Volumes[0].Name).To(Equal(configMapVolumeName))
 			Expect(pod.Spec.Volumes[0].ConfigMap).ToNot(BeNil())
@@ -48,29 +73,38 @@ var _ = Describe("GuestConversion", func() {
 		It("should create a volume and mount for each volume that belongs to the VM", func() {
 			vmSpec.Spec.Template.Spec.Volumes = []kubevirtv1.Volume{
 				{
-					Name: "volume1",
+					Name: "dv-1",
 					VolumeSource: kubevirtv1.VolumeSource{
 						DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv-1"},
 					},
 				},
 				{
-					Name: "volume2",
+					Name: "dv-2",
 					VolumeSource: kubevirtv1.VolumeSource{
 						DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv-2"},
 					},
 				},
+				{
+					Name: "dv-block",
+					VolumeSource: kubevirtv1.VolumeSource{
+						DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv-block"},
+					},
+				},
 			}
-			pod := MakeGuestConversionPodSpec(vmSpec, configMap)
-			Expect(len(pod.Spec.Volumes)).To(Equal(3))
+			pod := MakeGuestConversionPodSpec(vmSpec, dataVolumes, configMap)
+			Expect(len(pod.Spec.Volumes)).To(Equal(4))
 			Expect(pod.Spec.Volumes[0].Name).To(Equal("dv-1"))
 			Expect(pod.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal("dv-1"))
 
 			Expect(pod.Spec.Volumes[1].Name).To(Equal("dv-2"))
 			Expect(pod.Spec.Volumes[1].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal("dv-2"))
 
-			Expect(pod.Spec.Volumes[2].Name).To(Equal(configMapVolumeName))
-			Expect(pod.Spec.Volumes[2].ConfigMap).ToNot(BeNil())
-			Expect(pod.Spec.Volumes[2].ConfigMap.Name).To(Equal("testMap"))
+			Expect(pod.Spec.Volumes[2].Name).To(Equal("dv-block"))
+			Expect(pod.Spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal("dv-block"))
+
+			Expect(pod.Spec.Volumes[3].Name).To(Equal(configMapVolumeName))
+			Expect(pod.Spec.Volumes[3].ConfigMap).ToNot(BeNil())
+			Expect(pod.Spec.Volumes[3].ConfigMap.Name).To(Equal("testMap"))
 
 			Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(3))
 			Expect(pod.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("dv-1"))
@@ -78,25 +112,34 @@ var _ = Describe("GuestConversion", func() {
 			Expect(pod.Spec.Containers[0].VolumeMounts[1].Name).To(Equal("dv-2"))
 			Expect(pod.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal("/mnt/disks/disk1"))
 			Expect(pod.Spec.Containers[0].VolumeMounts[2].Name).To(Equal(configMapVolumeName))
+			Expect(pod.Spec.Containers[0].VolumeDevices[0].Name).To(Equal("dv-block"))
+			Expect(pod.Spec.Containers[0].VolumeDevices[0].DevicePath).To(Equal("/dev/block2"))
 		})
 	})
 
 	Describe("MakeLibvirtDomain", func() {
 		var vmSpec *kubevirtv1.VirtualMachine
 		var volumes []kubevirtv1.Volume
+		var dataVolumes map[string]cdiv1.DataVolume
 
 		BeforeEach(func() {
 			volumes = []kubevirtv1.Volume{
 				{
-					Name: "volume1",
+					Name: "dv-1",
 					VolumeSource: kubevirtv1.VolumeSource{
 						DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv-1"},
 					},
 				},
 				{
-					Name: "volume2",
+					Name: "dv-2",
 					VolumeSource: kubevirtv1.VolumeSource{
 						DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv-2"},
+					},
+				},
+				{
+					Name: "dv-block",
+					VolumeSource: kubevirtv1.VolumeSource{
+						DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv-block"},
 					},
 				},
 			}
@@ -125,15 +168,37 @@ var _ = Describe("GuestConversion", func() {
 					},
 				},
 			}
+			dataVolumes = map[string]cdiv1.DataVolume{
+				"dv-1": {
+					ObjectMeta: metav1.ObjectMeta{Name: "dv-1"},
+					Spec: cdiv1.DataVolumeSpec{
+						PVC: &v1.PersistentVolumeClaimSpec{VolumeMode: &volumeModeFilesystem},
+					},
+				},
+				"dv-2": {
+					ObjectMeta: metav1.ObjectMeta{Name: "dv-2"},
+					Spec: cdiv1.DataVolumeSpec{
+						PVC: &v1.PersistentVolumeClaimSpec{VolumeMode: &volumeModeFilesystem},
+					},
+				},
+				"dv-block": {
+					ObjectMeta: metav1.ObjectMeta{Name: "dv-block"},
+					Spec: cdiv1.DataVolumeSpec{
+						PVC: &v1.PersistentVolumeClaimSpec{VolumeMode: &volumeModeBlock},
+					},
+				},
+			}
 		})
 
 		It("should create a DomainDisk for each volume on the VM", func() {
-			domain := MakeLibvirtDomain(vmSpec)
-			Expect(len(domain.Devices.Disks)).To(Equal(2))
+			domain := MakeLibvirtDomain(vmSpec, dataVolumes)
+			Expect(len(domain.Devices.Disks)).To(Equal(3))
 			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal("/mnt/disks/disk0/disk.img"))
 			Expect(domain.Devices.Disks[0].Target.Dev).To(Equal("hda"))
 			Expect(domain.Devices.Disks[1].Source.File.File).To(Equal("/mnt/disks/disk1/disk.img"))
 			Expect(domain.Devices.Disks[1].Target.Dev).To(Equal("hdb"))
+			Expect(domain.Devices.Disks[2].Source.Block.Dev).To(Equal("/dev/block2"))
+			Expect(domain.Devices.Disks[2].Target.Dev).To(Equal("hdc"))
 		})
 	})
 })

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -3,6 +3,7 @@ package ovirtprovider
 import (
 	"errors"
 	"fmt"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"strings"
 
 	ctrlConfig "github.com/kubevirt/vm-import-operator/pkg/config/controller"
@@ -406,7 +407,7 @@ func (o *OvirtProvider) GetGuestConversionPod() (*corev1.Pod, error) {
 }
 
 // LaunchGuestConversionJob is not implemented.
-func (o *OvirtProvider) LaunchGuestConversionPod(_ *kubevirtv1.VirtualMachine) (*corev1.Pod, error) {
+func (o *OvirtProvider) LaunchGuestConversionPod(_ *kubevirtv1.VirtualMachine, _ map[string]cdiv1.DataVolume) (*corev1.Pod, error) {
 	return nil, nil
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -36,7 +36,7 @@ type Provider interface {
 	ProcessTemplate(*oapiv1.Template, *string, string) (*kubevirtv1.VirtualMachine, error)
 	NeedsGuestConversion() bool
 	GetGuestConversionPod() (*corev1.Pod, error)
-	LaunchGuestConversionPod(*kubevirtv1.VirtualMachine) (*corev1.Pod, error)
+	LaunchGuestConversionPod(*kubevirtv1.VirtualMachine, map[string]cdiv1.DataVolume) (*corev1.Pod, error)
 	SupportsWarmMigration() bool
 	CreateVMSnapshot() (string, error)
 }


### PR DESCRIPTION
Block devices need to be mounted as VolumeDevices rather
than VolumeMounts, otherwise the pod will get
stuck in ContainerCreating because the volumes can't be
attached.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1917908

Signed-off-by: Sam Lucidi <slucidi@redhat.com>