### PR TITLE
Fail import when V2V overlays can't be committed.

### DIFF
--- a/build/virtv2v/bin/entrypoint
+++ b/build/virtv2v/bin/entrypoint
@@ -7,8 +7,15 @@ virt-v2v -v -x -i libvirtxml -o null --debug-overlays --no-copy --root=first /mn
 [ $? != 0 ] && exit 1
 
 echo "Conversion successful. Committing all overlays to local disks."
-find /var/tmp -name '*.qcow2' -exec qemu-img commit -p {} \;
-[ $? != 0 ] && exit 1
+for OVERLAY in /var/tmp/*.qcow2
+do
+	if ! qemu-img commit -p "$OVERLAY"
+	then
+		echo Failed to commit overlay "$OVERLAY"!
+		echo Unable to complete import!
+		exit 1
+	fi
+done
 
 echo "Commit successful. Cleaning up."
 find /var/tmp -name '*.qcow2' -exec rm -f {} \;


### PR DESCRIPTION
Fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=1904797

The "find" command does not fail when one "qemu-img commit" fails, so the changes from virt-v2v were not saved back to the VM disk in the presence of NFS permissions errors. The resulting VM was not able to boot because of the lack of virtio drivers in the initramfs.

This pull request uses an explicit loop to return an error in this case, which should at least stop the import from being marked as successful.

```release-note
Fail import when V2V overlays can't be committed.
```