### PR TITLE
Add overhead to requested size when creating DVs

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -2083,7 +2083,7 @@ func (m *mockMapper) MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachi
 }
 
 // MapDataVolumes implements Mapper.MapDataVolumes
-func (m *mockMapper) MapDataVolumes(targetVMName *string) (map[string]cdiv1.DataVolume, error) {
+func (m *mockMapper) MapDataVolumes(targetVMName *string, overhead cdiv1.FilesystemOverhead) (map[string]cdiv1.DataVolume, error) {
 	return map[string]cdiv1.DataVolume{"123": {}}, nil
 }
 

--- a/pkg/controller/virtualmachineimport/warmimport.go
+++ b/pkg/controller/virtualmachineimport/warmimport.go
@@ -110,7 +110,7 @@ func (r *ReconcileVirtualMachineImport) ensureDisksExist(provider provider.Provi
 		}
 	}
 
-	dvs, err := mapper.MapDataVolumes(&vmName.Name)
+	dvs, err := mapper.MapDataVolumes(&vmName.Name, r.filesystemOverhead)
 	if err != nil {
 		return false, err
 	}
@@ -154,7 +154,7 @@ func (r *ReconcileVirtualMachineImport) ensureDisksExist(provider provider.Provi
 
 func (r *ReconcileVirtualMachineImport) isStageComplete(instance *v2vv1.VirtualMachineImport, mapper provider.Mapper, vmName types.NamespacedName) (bool, error) {
 	disksDoneStage := 0
-	dvs, err := mapper.MapDataVolumes(&vmName.Name)
+	dvs, err := mapper.MapDataVolumes(&vmName.Name, r.filesystemOverhead)
 	if err != nil {
 		return false, err
 	}
@@ -184,7 +184,7 @@ func (r *ReconcileVirtualMachineImport) isStageComplete(instance *v2vv1.VirtualM
 func (r *ReconcileVirtualMachineImport) setupNextStage(provider provider.Provider, instance *v2vv1.VirtualMachineImport, mapper provider.Mapper, vmName types.NamespacedName, final bool) error {
 	var snapshotRef string
 
-	dvs, err := mapper.MapDataVolumes(&vmName.Name)
+	dvs, err := mapper.MapDataVolumes(&vmName.Name, r.filesystemOverhead)
 	if err != nil {
 		return err
 	}

--- a/pkg/guestconversion/guestconversion.go
+++ b/pkg/guestconversion/guestconversion.go
@@ -2,8 +2,9 @@ package guestconversion
 
 import (
 	"fmt"
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"os"
+
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 
 	"kubevirt.io/containerized-data-importer/pkg/common"
 

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -177,6 +177,17 @@ func getControllerPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"cdiconfigs",
+			},
+			Verbs: []string{
+				"get",
+			},
+		},
+		{
+			APIGroups: []string{
 				"template.openshift.io",
 			},
 			Resources: []string{

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -3,9 +3,10 @@ package ovirtprovider
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
-	"strings"
 
 	ctrlConfig "github.com/kubevirt/vm-import-operator/pkg/config/controller"
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -46,7 +46,7 @@ type Mapper interface {
 	CreateEmptyVM(vmName *string) *kubevirtv1.VirtualMachine
 	ResolveVMName(targetVMName *string) *string
 	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
-	MapDataVolumes(targetVMName *string) (map[string]cdiv1.DataVolume, error)
+	MapDataVolumes(targetVMName *string, filesystemOverhead cdiv1.FilesystemOverhead) (map[string]cdiv1.DataVolume, error)
 	MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVolume)
 }
 

--- a/pkg/providers/vmware/provider.go
+++ b/pkg/providers/vmware/provider.go
@@ -3,6 +3,7 @@ package vmware
 import (
 	"encoding/xml"
 	"fmt"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,8 @@ import (
 	"time"
 	"unicode"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
+
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	v1 "kubevirt.io/client-go/api/v1"
 
@@ -354,4 +356,23 @@ func UpdateAnnotations(vm *v1.VirtualMachine, annotationMap map[string]string) {
 		vm.ObjectMeta.SetAnnotations(annotations)
 	}
 	AppendMap(annotations, annotationMap)
+}
+
+func GetOverheadForStorageClass(filesystemOverhead cdiv1.FilesystemOverhead, storageClass *string) float64 {
+	scName := ""
+	defaultOverhead := 0.055
+
+	if storageClass != nil {
+		scName = *storageClass
+	}
+
+	rawOverhead, ok := filesystemOverhead.StorageClass[scName]
+	if !ok {
+		rawOverhead = filesystemOverhead.Global
+	}
+	overhead, err := strconv.ParseFloat(string(rawOverhead), 64)
+	if err != nil {
+		overhead = defaultOverhead
+	}
+	return overhead
 }


### PR DESCRIPTION
This attempts to get the storage class filesystem overhead map from the CDIConfig. If it can't be found, it uses the default overhead  defined in CDI. The size of PVCs requested by the mapper is increased by the percentage defined in the map for that PVC's storage class, or by the default if no value was specified for that storage class.

https://bugzilla.redhat.com/show_bug.cgi?id=1864577

Signed-off-by: Sam Lucidi <slucidi@redhat.com>