### PR TITLE
Add validation that VMWare Tools are present

### DIFF
--- a/cluster/manifests/vcsim.yaml.in
+++ b/cluster/manifests/vcsim.yaml.in
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: cdi-sa
       containers:
       - name: vcsim
-        image: mansam/vcsim:latest
+        image: quay.io/slucidi/vcsim:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8989


### PR DESCRIPTION
vSphere VMs can't be shutdown gracefully unless the VMWare tools are present. This adds a validation to ensure that either the tools are present, or the VM is already powered off.

I've also fixed another validation that was accidentally commented out, and added tests for both.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>