### PR TITLE
Use VMI UID instead of vSphere UUID to name DVs

### DIFF
--- a/pkg/providers/vmware/mapper/mapper.go
+++ b/pkg/providers/vmware/mapper/mapper.go
@@ -90,6 +90,7 @@ type VmwareMapper struct {
 	credentials    *DataVolumeCredentials
 	disks          *[]disk
 	hostProperties *mo.HostSystem
+	instanceUID    string
 	mappings       *v1beta1.VmwareMappings
 	namespace      string
 	nics           *[]nic
@@ -99,10 +100,11 @@ type VmwareMapper struct {
 }
 
 // NewVmwareMapper creates a new VmwareMapper struct
-func NewVmwareMapper(vm *object.VirtualMachine, vmProperties *mo.VirtualMachine, hostProperties *mo.HostSystem, credentials *DataVolumeCredentials, mappings *v1beta1.VmwareMappings, namespace string, osFinder vos.OSFinder) *VmwareMapper {
+func NewVmwareMapper(vm *object.VirtualMachine, vmProperties *mo.VirtualMachine, hostProperties *mo.HostSystem, credentials *DataVolumeCredentials, mappings *v1beta1.VmwareMappings, instanceUID string, namespace string, osFinder vos.OSFinder) *VmwareMapper {
 	return &VmwareMapper{
 		credentials:    credentials,
 		hostProperties: hostProperties,
+		instanceUID:    instanceUID,
 		mappings:       mappings,
 		namespace:      namespace,
 		osFinder:       osFinder,
@@ -295,7 +297,7 @@ func (r *VmwareMapper) MapDataVolumes(_ *string, filesystemOverhead cdiv1.Filesy
 	dvs := make(map[string]cdiv1.DataVolume)
 
 	for _, disk := range *r.disks {
-		dvName := fmt.Sprintf("%s-%d", r.vmProperties.Config.Uuid, disk.key)
+		dvName := fmt.Sprintf("%s-%d", r.instanceUID, disk.key)
 
 		mapping := r.getMappingForDisk(disk)
 

--- a/pkg/providers/vmware/mapper/mapper_test.go
+++ b/pkg/providers/vmware/mapper/mapper_test.go
@@ -23,6 +23,7 @@ import (
 var (
 	vmMoRef      = "vm-70"
 	targetVMName = "basic-vm"
+	instanceUID  = "d39a8d6c-ea37-5c91-8979-334e7e07cab6"
 
 	// vm attributes
 	memoryReservationStr       = "2048Mi"
@@ -45,8 +46,8 @@ var (
 	diskBytes1        = 2147483648
 	diskName2         = "disk-202-1"
 	diskBytes2        = 1073741824
-	expectedDiskName1 = "c39a8d6c-ea37-5c91-8979-334e7e07cab5-203"
-	expectedDiskName2 = "c39a8d6c-ea37-5c91-8979-334e7e07cab5-205"
+	expectedDiskName1 = "d39a8d6c-ea37-5c91-8979-334e7e07cab6-203"
+	expectedDiskName2 = "d39a8d6c-ea37-5c91-8979-334e7e07cab6-205"
 
 	volumeModeBlock      = v1.PersistentVolumeBlock
 	volumeModeFilesystem = v1.PersistentVolumeFilesystem
@@ -124,7 +125,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map name", func() {
 		mappings := createMinimalMapping()
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -133,7 +134,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map memory reservation", func() {
 		mappings := createMinimalMapping()
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -143,7 +144,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map machine type", func() {
 		mappings := createMinimalMapping()
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -152,7 +153,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map CPU topology", func() {
 		mappings := createMinimalMapping()
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -163,7 +164,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map timezone", func() {
 		mappings := createMinimalMapping()
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -172,7 +173,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map pod network by moref", func() {
 		mappings := createPodNetworkMapping(true)
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -193,7 +194,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map pod network by name", func() {
 		mappings := createPodNetworkMapping(false)
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -214,7 +215,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map multus network by network moref", func() {
 		mappings := createMultusNetworkMapping(true)
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -235,7 +236,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should map multus network by name", func() {
 		mappings := createMultusNetworkMapping(false)
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -256,7 +257,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should disable NetworkInterfaceMultiQueue when there are no mapped interfaces", func() {
 		mappings := createMinimalMapping()
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 		Expect(err).To(BeNil())
 
@@ -272,7 +273,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 
 	It("should remove any networks or interfaces from the template", func() {
 		mappings := &v1beta1.VmwareMappings{}
-		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		vmMapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		vmSpec, err := vmMapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{
 			Spec: kubevirtv1.VirtualMachineSpec{
 				Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -338,7 +339,7 @@ var _ = Describe("Test mapping disks", func() {
 				},
 			},
 		}
-		mapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, "", osFinder)
+		mapper := mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, mappings, instanceUID, "", osFinder)
 		dvs, _ := mapper.MapDataVolumes(&targetVMName, filesystemOverhead)
 		Expect(dvs).To(HaveLen(expectedNumDisks))
 		Expect(dvs).To(HaveKey(expectedDiskName1))

--- a/pkg/providers/vmware/provider.go
+++ b/pkg/providers/vmware/provider.go
@@ -151,7 +151,7 @@ func (r *VmwareProvider) CreateMapper() (provider.Mapper, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, r.resourceMapping, r.vmiObjectMeta.Namespace, r.osFinder), nil
+	return mapper.NewVmwareMapper(vm, vmProperties, hostProperties, credentials, r.resourceMapping, string(r.vmiObjectMeta.UID), r.vmiObjectMeta.Namespace, r.osFinder), nil
 }
 
 // FindTemplate attempts to find best match for a template based on the source VM

--- a/tests/vmware/basic_net_vm_import_test.go
+++ b/tests/vmware/basic_net_vm_import_test.go
@@ -2,6 +2,7 @@ package vmware_test
 
 import (
 	"context"
+	"fmt"
 	v2vv1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	"github.com/kubevirt/vm-import-operator/tests"
 	fwk "github.com/kubevirt/vm-import-operator/tests/framework"
@@ -57,7 +58,7 @@ var _ = Describe("Networked VM import ", func() {
 		vmBlueprint := v1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: retrieved.Status.TargetVMName, Namespace: namespace}}
 		Expect(vmBlueprint).To(BeRunning(f))
 
-		vm := test.validateTargetConfiguration(vmBlueprint.Name)
+		vm := test.validateTargetConfiguration(vmBlueprint.Name, string(created.UID))
 		Expect(vm.Spec.Template.Spec.Volumes[0].DataVolume.Name).To(HaveDefaultStorageClass(f))
 	},
 		table.Entry("when type in network resource mapping is 'pod'", &tests.PodType),
@@ -65,7 +66,7 @@ var _ = Describe("Networked VM import ", func() {
 	)
 })
 
-func (t *networkedVMImportTest) validateTargetConfiguration(vmName string) *v1.VirtualMachine {
+func (t *networkedVMImportTest) validateTargetConfiguration(vmName string, uid string) *v1.VirtualMachine {
 	vmNamespacedName := types.NamespacedName{Name: vmName, Namespace: t.framework.Namespace.Name}
 
 	vm := &v1.VirtualMachine{}
@@ -103,10 +104,10 @@ func (t *networkedVMImportTest) validateTargetConfiguration(vmName string) *v1.V
 	Expect(disks).To(HaveLen(2))
 	disk0 := disks[0]
 	Expect(disk0.Disk.Bus).To(BeEquivalentTo("virtio"))
-	Expect(disk0.Name).To(BeEquivalentTo("dv-c39a8d6c-ea37-5c91-8979-334e7e07cab5-203"))
+	Expect(disk0.Name).To(BeEquivalentTo(fmt.Sprintf("dv-%s-203", uid)))
 	disk1 := disks[1]
 	Expect(disk1.Disk.Bus).To(BeEquivalentTo("virtio"))
-	Expect(disk1.Name).To(BeEquivalentTo("dv-c39a8d6c-ea37-5c91-8979-334e7e07cab5-205"))
+	Expect(disk1.Name).To(BeEquivalentTo(fmt.Sprintf("dv-%s-205", uid)))
 
 	By("having correct volumes")
 	Expect(spec.Volumes).To(HaveLen(2))


### PR DESCRIPTION
Using the source VM UUID to name DataVolumes causes a problem if the user attempts to import the same source VM to the same namespace a second time with a different target name. Using the unique ID from the VirtualMachineImport sidesteps this.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>