### PR TITLE
Add annotation to allow retaining the v2v pod after a successful import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.x
+  - 1.14.x
 
 env:
   - RELEASE_VERSION=v0.15.2 GO111MODULE=on

--- a/pkg/providers/vmware/provider.go
+++ b/pkg/providers/vmware/provider.go
@@ -53,6 +53,8 @@ const (
 
 	warmMigrationSnapshotName        = "warm-migration-stage"
 	warmMigrationSnapshotDescription = "VM Import Operator warm migration stage"
+
+	annRetainConversionPod = "vmimport.v2v.kubevirt.io/retain-conversion-pod"
 )
 
 // VmwareProvider is VMware implementation of the Provider interface to support importing VMs from VMware
@@ -327,9 +329,9 @@ func (r *VmwareProvider) CleanUp(failure bool, cr *v1beta1.VirtualMachineImport,
 		}
 	}
 
-	// only clean up the pod on success,
-	// since the pod log is important for debugging
-	if !failure {
+	// keep the conversion pod around if it failed or the annotation was set
+	_, found := cr.Annotations[annRetainConversionPod]
+	if !(failure || found) {
 		err = r.podsManager.DeleteFor(vmiName)
 		if err != nil {
 			errs = append(errs, err)

--- a/tests/framework/node.go
+++ b/tests/framework/node.go
@@ -58,14 +58,6 @@ func (f *Framework) GetAllSchedulableNodes() (*k8sv1.NodeList, error) {
 // both iptables and newer nftables.
 // Based on https://github.com/kubevirt/kubevirt/blob/master/tests/vmi_multus_test.go
 func (f *Framework) ConfigureNodeNetwork() error {
-	// Fetching the kubevirt-operator image from the pod makes this independent from the installation method / image used
-	pods, err := f.K8sClient.CoreV1().Pods(f.KubeVirtInstallNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
-	if err != nil {
-		return err
-	}
-
-	virtOperatorImage := pods.Items[0].Spec.Containers[0].Image
-
 	// Privileged DaemonSet configuring host networking as needed
 	networkConfigDaemonSet := appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
@@ -90,7 +82,7 @@ func (f *Framework) ConfigureNodeNetwork() error {
 							Name: "network-config",
 							// Reuse image which is already installed in the cluster. All we need is chroot.
 							// Local OKD cluster doesn't allow us to pull from the outside.
-							Image: virtOperatorImage,
+							Image: "centos:8",
 							Command: []string{
 								"sh",
 								"-c",


### PR DESCRIPTION
Adds an annotation `vmimport.v2v.kubevirt.io/retain-conversion-pod` which if set will cause the virt-v2v conversion pod to be retained even after a successful import. This is to permit troubleshooting in a situation where the virt-v2v conversion superficially appears to have succeeded, but the VM fails to start correctly.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>