### PR TITLE
Propagate transfer network annotations to DataVolumes

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -981,10 +981,20 @@ var _ = Describe("Reconcile steps", func() {
 				return nil
 			}
 
+			annotations := make(map[string]string)
+			annotations[AnnDVNetwork] = "annDVNetwork"
+			annotations[AnnDVMultusNetwork] = "annDVMultusNetwork"
+			instance.SetAnnotations(annotations)
+
 			dv := cdiv1.DataVolume{}
 			_, err := reconciler.createDataVolume(mock, mapper, instance, &dv, vmName)
 
 			Expect(err).To(BeNil())
+
+			// ensure that DV transfer network annotations were propagated from VMI to DVs
+			Expect(dv.Annotations).ToNot(BeNil())
+			Expect(dv.Annotations[AnnDVNetwork]).To(Equal("annDVNetwork"))
+			Expect(dv.Annotations[AnnDVMultusNetwork]).To(Equal("annDVMultusNetwork"))
 		})
 	})
 


### PR DESCRIPTION
This PR allows network selection annotations to be set on the VMI CR, which will then be propagated to the DataVolumes. Documentation for these annotations in CDI is here: https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolume-annotations.md

Signed-off-by: Sam Lucidi <slucidi@redhat.com>