### PR TITLE
Fix warm import finalization edge case

### DIFF
--- a/pkg/controller/virtualmachineimport/warmimport.go
+++ b/pkg/controller/virtualmachineimport/warmimport.go
@@ -17,8 +17,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// if the finalization date is already past and we haven't captured a snapshot yet,
+// then we should just proceed with a cold import.
+func skipWarmImport(instance *v2vv1.VirtualMachineImport) bool {
+	return shouldFinalizeWarmImport(instance) && instance.Status.WarmImport.RootSnapshot == nil
+}
+
 func shouldWarmImport(provider provider.Provider, instance *v2vv1.VirtualMachineImport) bool {
-	return provider.SupportsWarmMigration() && instance.Spec.Warm
+	return provider.SupportsWarmMigration() && instance.Spec.Warm && !skipWarmImport(instance)
 }
 
 func shouldFinalizeWarmImport(instance *v2vv1.VirtualMachineImport) bool {


### PR DESCRIPTION
If a warm VirtualMachineImport's finalization date was already past before taking the first snapshot, then proceed as though a cold migration was requested. This fixes an issue I noticed where if the finalization date was already past before the first stage was created, it would attempt to find DataVolumes that hadn't been created yet.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>