### PR TITLE
Requeue while waiting for disk copies and guest conversion to complete

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -398,7 +398,7 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 
 		if !done {
 			reqLogger.Info("Waiting for disks to be imported")
-			return reconcile.Result{}, nil
+			return reconcile.Result{RequeueAfter: SlowReQ}, nil
 		}
 	}
 
@@ -410,7 +410,7 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 
 		if !done {
 			reqLogger.Info("Waiting for guest to be converted")
-			return reconcile.Result{}, nil
+			return reconcile.Result{RequeueAfter: SlowReQ}, nil
 		}
 	}
 

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -1689,7 +1689,7 @@ var _ = Describe("Reconcile steps", func() {
 			Expect(event).To(ContainSubstring("ImportInProgress"))
 
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: SlowReQ}))
 		})
 
 		It("should fail to start vm: ", func() {
@@ -1738,7 +1738,7 @@ var _ = Describe("Reconcile steps", func() {
 			result, err := reconciler.Reconcile(request)
 
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: SlowReQ}))
 		})
 
 		It("should exit early if vm condition is succeed: ", func() {
@@ -1864,7 +1864,8 @@ var _ = Describe("Reconcile steps", func() {
 				result, err := reconciler.Reconcile(request)
 
 				Expect(err).To(BeNil())
-				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: SlowReQ}))
 				Expect(config.Finalizers).To(Not(BeNil()))
 				Expect(config.Annotations[AnnCurrentProgress]).To(Not(BeNil()))
 


### PR DESCRIPTION
Imports are sometimes getting stuck waiting for disks
to copy or guest conversion to complete, even though
the datavolumes or v2v pod are done. Forcing the
VMI to reconcile (e.g. by manually adding an annotation)
allows the status change to be picked up and import to
complete successfully.

This PR causes VMIs to requeue themselves while waiting
for disk copy and guest conversion to be completed, to
prevent imports from getting stuck like this.

https://bugzilla.redhat.com/show_bug.cgi?id=1946884

Signed-off-by: Sam Lucidi <slucidi@redhat.com>