### PR TITLE
Start VMs so WaitForFirstConsumer DVs can bind

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -2102,6 +2102,11 @@ func (m *mockMapper) MapDataVolumes(targetVMName *string, overhead cdiv1.Filesys
 func (m *mockMapper) MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVolume) {
 }
 
+// RunningState implements Mapper.RunningState
+func (m *mockMapper) RunningState() bool {
+	return false
+}
+
 // NewOvirtClient implements Factory.NewOvirtClient
 func (f *mockFactory) NewOvirtClient(dataMap map[string]string) (pclient.VMClient, error) {
 	return &mockOvirtClient{}, nil

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -227,6 +227,16 @@ func (o *OvirtMapper) MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVo
 	vmSpec.Spec.Template.Spec.Domain.Devices.Disks = append(vmSpec.Spec.Template.Spec.Domain.Devices.Disks, disk)
 }
 
+// RunningState determines whether the created Kubevirt vmSpec should
+// have a running state of true or false.
+func (o *OvirtMapper) RunningState() bool {
+	running := o.mapHighAvailability()
+	if running != nil {
+		return *running
+	}
+	return false
+}
+
 // If the mapping specifies the access mode return that, otherwise determine the access mode
 // of the PVC based on the VM's disk read only attribute and based on the affinity settings of the VM.
 func (o *OvirtMapper) getAccessMode(diskAttachment *ovirtsdk.DiskAttachment, mapping *v2vv1.StorageResourceMappingItem) corev1.PersistentVolumeAccessMode {

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -48,6 +48,7 @@ type Mapper interface {
 	MapVM(targetVMName *string, vmSpec *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
 	MapDataVolumes(targetVMName *string, filesystemOverhead cdiv1.FilesystemOverhead) (map[string]cdiv1.DataVolume, error)
 	MapDisk(vmSpec *kubevirtv1.VirtualMachine, dv cdiv1.DataVolume)
+	RunningState() bool
 }
 
 // VMStatus represents VM status

--- a/pkg/providers/vmware/mapper/mapper.go
+++ b/pkg/providers/vmware/mapper/mapper.go
@@ -509,6 +509,12 @@ func (r *VmwareMapper) MapVM(targetVmName *string, vmSpec *kubevirtv1.VirtualMac
 	return vmSpec, nil
 }
 
+// RunningState determines whether the created Kubevirt vmSpec should
+// have a running state of true or false.
+func (r *VmwareMapper) RunningState() bool {
+	return false
+}
+
 func (r *VmwareMapper) mapLabels(vmLabels map[string]string) map[string]string {
 	var labels map[string]string
 	if vmLabels == nil {


### PR DESCRIPTION
Adds a check to see whether the DVs are in the WaitForFirstConsumer phase. If so, the Kubevirt VM will be started so that the DVs can bind. On the subsequent reconcile the VM's running state will be restored to the original mapped value.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1943304

Signed-off-by: Sam Lucidi <slucidi@redhat.com>