### PR TITLE
Validate that vSphere networks are mapped

### DIFF
--- a/pkg/apis/v2v/v1beta1/resourcemapping_types.go
+++ b/pkg/apis/v2v/v1beta1/resourcemapping_types.go
@@ -48,8 +48,8 @@ type OvirtMappings struct {
 // +k8s:openapi-gen=true
 type VmwareMappings struct {
 	// NetworkMappings defines the mapping of guest network interfaces to kubevirt networks
-	// NetworkMappings.Source.Name represents the `network` field of the GuestNicInfo in vCenter
-	// NetworkMappings.Source.ID represents the `macAddress` field of the network adapter
+	// NetworkMappings.Source.Name represents name of the vSphere network
+	// NetworkMappings.Source.ID represents the managed object id of the network or dvportgroup
 	// +optional
 	NetworkMappings *[]NetworkResourceMappingItem `json:"networkMappings,omitempty"`
 

--- a/tests/vmware/basic_vm_import_negative_test.go
+++ b/tests/vmware/basic_vm_import_negative_test.go
@@ -119,7 +119,7 @@ var _ = Describe("VM import", func() {
 		vmi := utils.VirtualMachineImportCr(fwk.ProviderVmware, vmware.VM70, namespace, secret.Name, f.NsPrefix, true)
 		vmi.Spec.Source.Vmware.Mappings = &v2vv1.VmwareMappings{
 			NetworkMappings: &[]v2vv1.NetworkResourceMappingItem{
-				{Source: v2vv1.Source{ID: &vmware.VM70Network}, Type: &tests.PodType},
+				{Source: v2vv1.Source{Name: &vmware.VM70Network}, Type: &tests.PodType},
 			},
 		}
 		created, err := f.VMImportClient.V2vV1beta1().VirtualMachineImports(namespace).Create(context.TODO(), &vmi, metav1.CreateOptions{})

--- a/tests/vmware/basic_vm_warm_import_test.go
+++ b/tests/vmware/basic_vm_warm_import_test.go
@@ -2,6 +2,7 @@ package vmware_test
 
 import (
 	"context"
+	"github.com/kubevirt/vm-import-operator/tests"
 	"github.com/kubevirt/vm-import-operator/tests/vmware"
 	"time"
 
@@ -35,6 +36,11 @@ var _ = Describe("Basic VM warm import ", func() {
 
 	It("should finalize a warm import", func() {
 		vmi := utils.VirtualMachineImportCr(fwk.ProviderVmware, vmware.VM66, namespace, secret.Name, f.NsPrefix, false)
+		vmi.Spec.Source.Vmware.Mappings = &v2vv1.VmwareMappings{
+			NetworkMappings: &[]v2vv1.NetworkResourceMappingItem{
+				{Source: v2vv1.Source{Name: &vmware.VM66Network}, Type: &tests.PodType},
+			},
+		}
 		vmi.Spec.Warm = true
 		finalize := metav1.NewTime(time.Now().Add(time.Duration(2) * time.Minute))
 		vmi.Spec.FinalizeDate = &finalize

--- a/tests/vmware/cancel_vm_import_test.go
+++ b/tests/vmware/cancel_vm_import_test.go
@@ -3,6 +3,7 @@ package vmware_test
 import (
 	"context"
 	"fmt"
+	"github.com/kubevirt/vm-import-operator/tests"
 	"github.com/kubevirt/vm-import-operator/tests/vmware"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "kubevirt.io/client-go/api/v1"
@@ -40,6 +41,11 @@ var _ = Describe("VM import cancellation ", func() {
 		}
 		vmImports = f.VMImportClient.V2vV1beta1().VirtualMachineImports(namespace)
 		cr := utils.VirtualMachineImportCr(framework.ProviderVmware, vmware.VM66, namespace, secret.Name, f.NsPrefix, true)
+		cr.Spec.Source.Vmware.Mappings = &v2vv1.VmwareMappings{
+			NetworkMappings: &[]v2vv1.NetworkResourceMappingItem{
+				{Source: v2vv1.Source{Name: &vmware.VM66Network}, Type: &tests.PodType},
+			},
+		}
 		vmi, err = vmImports.Create(context.TODO(), &cr, metav1.CreateOptions{})
 		if err != nil {
 			Fail(err.Error())

--- a/tests/vmware/definitions.go
+++ b/tests/vmware/definitions.go
@@ -13,9 +13,10 @@ var (
 )
 
 // vcsim/0051-VirtualMachine-vm-66.xml
-// vm-66 has no networks and one disk
+// vm-66 has one network and one disk
 var (
 	VM66 = "f7c371d6-2003-5a48-9859-3bc9a8b08908"
+	VM66Network = "ethernet-0"
 	VM66DiskName = "disk-202-0"
 	VM66Datastore = "/tmp/govcsim-DC0-LocalDS_0-024565671@folder-5"
 	VM66DatastoreName = "LocalDS_0"

--- a/tests/vmware/resource_mapping_test.go
+++ b/tests/vmware/resource_mapping_test.go
@@ -80,6 +80,9 @@ var _ = Describe("VM import ", func() {
 				StorageMappings: &[]v2vv1.StorageResourceMappingItem{
 					{Source: v2vv1.Source{ID: &vmware.VM66Datastore}, Target: v2vv1.ObjectIdentifier{Name: f.DefaultStorageClass}},
 				},
+				NetworkMappings: &[]v2vv1.NetworkResourceMappingItem{
+					{Source: v2vv1.Source{Name: &vmware.VM66Network}, Type: &tests.PodType},
+				},
 			}
 			rm, err := f.CreateVmwareResourceMapping(mappings)
 			if err != nil {


### PR DESCRIPTION
Added validations to ensure that all networks on vSphere VMs are mapped, and that no more than one network is mapped to the pod network.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1924104

Signed-off-by: Sam Lucidi slucidi@redhat.com