### PR TITLE
Clean up warm migration snapshots

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -312,11 +312,20 @@ func (r *ReconcileVirtualMachineImport) Reconcile(request reconcile.Request) (re
 	}
 	defer provider.Close()
 
-	if instance.DeletionTimestamp != nil && utils.HasFinalizer(instance, utils.RestoreVMStateFinalizer) {
-		err := r.finalize(instance, provider)
-		if err != nil {
-			// requeue if locked
-			return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
+	if instance.DeletionTimestamp != nil {
+		if utils.HasFinalizer(instance, utils.RestoreVMStateFinalizer) {
+			err := r.finalize(instance, provider)
+			if err != nil {
+				// requeue if locked
+				return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
+			}
+		}
+		if utils.HasFinalizer(instance, utils.CleanupSnapshotsFinalizer) && instance.Status.WarmImport.RootSnapshot != nil {
+			_ = provider.RemoveVMSnapshot(*instance.Status.WarmImport.RootSnapshot, true)
+			err = utils.RemoveFinalizer(instance, utils.CleanupSnapshotsFinalizer, r.client)
+			if err != nil {
+				reqLogger.Error(err, "Finalizing - failed to remove snapshot finalizer")
+			}
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -63,6 +63,7 @@ var (
 	launchGuestConversionPod func() (*corev1.Pod, error)
 	supportsWarmMigration    func() bool
 	createVMSnapshot         func() (string, error)
+	removeVMSnapshot         func(string, bool) error
 )
 
 var _ = Describe("Reconcile steps", func() {
@@ -2076,6 +2077,10 @@ func (p *mockProvider) SupportsWarmMigration() bool {
 
 func (p *mockProvider) CreateVMSnapshot() (string, error) {
 	return createVMSnapshot()
+}
+
+func (p *mockProvider) RemoveVMSnapshot(snapshotID string, removeChildren bool) error {
+	return removeVMSnapshot(snapshotID, removeChildren)
 }
 
 // CreateEmptyVM implements Mapper.CreateEmptyVM

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -425,6 +425,11 @@ func (o *OvirtProvider) CreateVMSnapshot() (string, error) {
 	return "", nil
 }
 
+// RemoveVMSnapshot is not implemented.
+func (o *OvirtProvider) RemoveVMSnapshot(_ string, _ bool) error {
+	return nil
+}
+
 func (o *OvirtProvider) prepareDataVolumeCredentials() (mapper.DataVolumeCredentials, error) {
 	keyAccess := o.ovirtSecretDataMap["username"]
 	keySecret := o.ovirtSecretDataMap["password"]

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -39,6 +39,7 @@ type Provider interface {
 	LaunchGuestConversionPod(*kubevirtv1.VirtualMachine, map[string]cdiv1.DataVolume) (*corev1.Pod, error)
 	SupportsWarmMigration() bool
 	CreateVMSnapshot() (string, error)
+	RemoveVMSnapshot(string, bool) error
 }
 
 // Mapper is interface to be used for mapping external VM to kubevirt VM

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,6 +24,9 @@ const (
 	// RestoreVMStateFinalizer defines restore source vm finalizer
 	RestoreVMStateFinalizer = "vmimport.v2v.kubevirt.io/restore-state"
 
+	// CleanupSnapshotsFinalizer defines a finalizer to remove warm import snapshots
+	CleanupSnapshotsFinalizer = "vmimport.v2v.kubevirt.io/cleanup-snapshots"
+
 	// Finalaizer for handling cancelled import
 	CancelledImportFinalizer = "vmimport.v2v.kubevirt.io/cancelled-import"
 )


### PR DESCRIPTION
* Delete snapshots that are no longer needed as new ones are created.
* Add a finalizer to ensure VM snapshots are cleaned up when a warm migration is canceled.
* Fix some bugs which were resulting in extra snapshots being created at the start of a warm migration which were not being cleaned up.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1957095
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1957333
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1942651
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1956925

Signed-off-by: Sam Lucidi <slucidi@redhat.com>