### PR TITLE
Remove KubeVirt feature gate checks

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,8 +9,6 @@ import (
 
 	ctrlConfig "github.com/kubevirt/vm-import-operator/pkg/config/controller"
 
-	kvConfig "github.com/kubevirt/vm-import-operator/pkg/config/kubevirt"
-
 	"k8s.io/client-go/kubernetes"
 
 	clientutil "kubevirt.io/client-go/util"
@@ -139,11 +137,10 @@ func main() {
 	stop := make(chan struct{})
 	defer close(stop)
 
-	kvConfigProvider := kvConfig.NewKubeVirtConfigProvider(stop, k8sClient, kubevirtNamespace)
 	ctrlConfigProvider := ctrlConfig.NewControllerConfigProvider(stop, k8sClient, kubevirtNamespace)
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr, &kvConfigProvider, &ctrlConfigProvider); err != nil {
+	if err := controller.AddToManager(mgr, &ctrlConfigProvider); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,17 +2,16 @@ package controller
 
 import (
 	ctrlConfig "github.com/kubevirt/vm-import-operator/pkg/config/controller"
-	kvConfig "github.com/kubevirt/vm-import-operator/pkg/config/kubevirt"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, kvConfig.KubeVirtConfigProvider, ctrlConfig.ControllerConfigProvider) error
+var AddToManagerFuncs []func(manager.Manager, ctrlConfig.ControllerConfigProvider) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, kvConfigProvider kvConfig.KubeVirtConfigProvider, ctrlConfigProvider ctrlConfig.ControllerConfigProvider) error {
+func AddToManager(m manager.Manager, ctrlConfigProvider ctrlConfig.ControllerConfigProvider) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, kvConfigProvider, ctrlConfigProvider); err != nil {
+		if err := f(m, ctrlConfigProvider); err != nil {
 			return err
 		}
 	}

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -10,8 +10,6 @@ import (
 
 	ctrlConfig "github.com/kubevirt/vm-import-operator/pkg/config/controller"
 
-	kvConfig "github.com/kubevirt/vm-import-operator/pkg/config/kubevirt"
-
 	"github.com/kubevirt/vm-import-operator/pkg/ownerreferences"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,8 +78,8 @@ type OvirtProvider struct {
 }
 
 // NewOvirtProvider creates new OvirtProvider configured with dependencies
-func NewOvirtProvider(vmiObjectMeta metav1.ObjectMeta, vmiTypeMeta metav1.TypeMeta, client client.Client, tempClient *tempclient.TemplateV1Client, factory pclient.Factory, kvConfigProvider kvConfig.KubeVirtConfigProvider, ctrlConfig ctrlConfig.ControllerConfig) OvirtProvider {
-	validator := validators.NewValidatorWrapper(client, kvConfigProvider)
+func NewOvirtProvider(vmiObjectMeta metav1.ObjectMeta, vmiTypeMeta metav1.TypeMeta, client client.Client, tempClient *tempclient.TemplateV1Client, factory pclient.Factory, ctrlConfig ctrlConfig.ControllerConfig) OvirtProvider {
+	validator := validators.NewValidatorWrapper(client)
 	secretsManager := secrets.NewManager(client)
 	configMapsManager := configmaps.NewManager(client)
 	datavolumesManager := datavolumes.NewManager(client)

--- a/pkg/providers/ovirt/validation/validators/vm-validator.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator.go
@@ -6,8 +6,6 @@ import (
 	"math"
 	"strings"
 
-	kvConfig "github.com/kubevirt/vm-import-operator/pkg/config/kubevirt"
-
 	"github.com/kubevirt/vm-import-operator/pkg/utils"
 
 	"github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/mapper"
@@ -22,7 +20,7 @@ type rule struct {
 }
 
 // ValidateVM validates given VM
-func ValidateVM(vm *ovirtsdk.Vm, config kvConfig.KubeVirtConfig, finder *otemplates.TemplateFinder) []ValidationFailure {
+func ValidateVM(vm *ovirtsdk.Vm, finder *otemplates.TemplateFinder) []ValidationFailure {
 	var results = isValidBios(vm)
 	if failure, valid := isValidStatus(vm); !valid {
 		results = append(results, failure)
@@ -60,9 +58,6 @@ func ValidateVM(vm *ovirtsdk.Vm, config kvConfig.KubeVirtConfig, finder *otempla
 		results = append(results, failure)
 	}
 	if failure, valid := isValidOrigin(vm); !valid {
-		results = append(results, failure)
-	}
-	if failure, valid := isValidPlacementPolicy(vm, config.LiveMigrationEnabled()); !valid {
 		results = append(results, failure)
 	}
 	if failure, valid := isValidRandomNumberGeneratorSource(vm); !valid {


### PR DESCRIPTION
KubeVirt LiveMigration being enabled or not has no bearing on whether or not an oVirt VM can be migrated to it, so this should not block import.

ImportWithoutTemplate is not a legitimate KubeVirt feature gate as defined by the [KubeVirt source](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/feature-gates.go#L26), so it should be removed. It seems unlikely that anyone was actually using this as it was off by default and not in the KubeVirt documentation. If this is actually useful it should be reimplemented as a VMIO configuration option.