### PR TITLE
Remove dependency on obsolete Kubevirt config map

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -92,4 +92,3 @@ ID | Predicate | Action
 31 | VM.floppies[] is not empty | Log
 32 | vm.timezone is not UTC-compatible | Block
 33 | vm.status other than 'up' or 'down' | Block
-34 | vm. placement_policy.affinity='migratable' and KubeVirt has Live Migration disabled | Block

--- a/pkg/config/controller/config.go
+++ b/pkg/config/controller/config.go
@@ -22,6 +22,9 @@ const (
 	// WarmImportIntervalMinutesKey defines how long to wait between warm import iterations
 	WarmImportIntervalMinutesKey     = "warmImport.intervalMinutes"
 	warmImportIntervalMinutesDefault = 60
+	// ImportWithoutTemplateKey defines whether imports are permitted to run if an Openshift VM template can't be found.
+	ImportWithoutTemplateKey         = "importWithoutTemplate"
+	importWithoutTemplateDefault     = false
 )
 
 // ControllerConfig stores controller runtime configuration
@@ -56,6 +59,19 @@ func (c ControllerConfig) WarmImportConsecutiveFailures() int {
 
 func (c ControllerConfig) WarmImportIntervalMinutes() int {
 	return c.getKeyAsInt(WarmImportIntervalMinutesKey, warmImportIntervalMinutesDefault, 0)
+}
+
+func (c ControllerConfig) ImportWithoutTemplateEnabled() bool {
+	return c.getKeyAsBool(ImportWithoutTemplateKey, importWithoutTemplateDefault)
+}
+
+func (c ControllerConfig) getKeyAsBool(key string, default_ bool) bool {
+	raw := c.ConfigMap.Data[key]
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		parsed = default_
+	}
+	return parsed
 }
 
 func (c ControllerConfig) getKeyAsInt(key string, default_ int, floor int) int {

--- a/pkg/config/kubevirt/config.go
+++ b/pkg/config/kubevirt/config.go
@@ -38,11 +38,6 @@ type KubeVirtConfig struct {
 	FeatureGates string
 }
 
-// LiveMigrationEnabled returns true if LiveMigration KubeVirt feature gate is enabled
-func (c *KubeVirtConfig) LiveMigrationEnabled() bool {
-	return c.isFeatureGateEnabled(liveMigrationGate)
-}
-
 // ImportWithoutTemplateEnabled returns true if ImportWithoutTemplate KubeVirt feature gate is enabled
 func (c *KubeVirtConfig) ImportWithoutTemplateEnabled() bool {
 	return c.isFeatureGateEnabled(importWithoutTemplateGate)

--- a/pkg/config/kubevirt/config_test.go
+++ b/pkg/config/kubevirt/config_test.go
@@ -8,46 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Live migration in KubeVirt config ", func() {
-	table.DescribeTable("should be enabled for: ", func(featureGates string) {
-		cfg := kubevirt.KubeVirtConfig{
-			FeatureGates: featureGates,
-		}
-
-		enabled := cfg.LiveMigrationEnabled()
-
-		Expect(enabled).To(BeTrue())
-	},
-		table.Entry("only LiveMigration", "LiveMigration"),
-		table.Entry("LiveMigration among others", "Foo,LiveMigration,Bar"),
-	)
-
-	table.DescribeTable("should be disabled for: ", func(featureGates string) {
-		cfg := kubevirt.KubeVirtConfig{
-			FeatureGates: featureGates,
-		}
-
-		enabled := cfg.LiveMigrationEnabled()
-
-		Expect(enabled).To(BeFalse())
-	},
-		table.Entry("empty feature gates", ""),
-		table.Entry("feature gates other than LiveMigration", "Foo,Bar"),
-	)
-
-	It("should create KubeVirt config", func() {
-		featureGates := "LiveMigration"
-		configMap := corev1.ConfigMap{
-			Data: map[string]string{"feature-gates": featureGates},
-		}
-		cfg := kubevirt.NewKubeVirtConfig(configMap)
-
-		Expect(cfg.FeatureGates).To(BeEquivalentTo(featureGates))
-		Expect(cfg.LiveMigrationEnabled()).To(BeTrue())
-		Expect(cfg.ConfigMap).To(BeEquivalentTo(configMap))
-	})
-})
-
 var _ = Describe("Import without templates in KubeVirt config ", func() {
 	table.DescribeTable("should be enabled for: ", func(featureGates string) {
 		cfg := kubevirt.KubeVirtConfig{
@@ -77,7 +37,7 @@ var _ = Describe("Import without templates in KubeVirt config ", func() {
 })
 
 var _ = Describe("KubeVirt config creator", func() {
-	featureGates := "LiveMigration"
+	featureGates := "ImportWithoutTemplate"
 	configMap := corev1.ConfigMap{
 		Data: map[string]string{"feature-gates": featureGates},
 	}
@@ -89,9 +49,5 @@ var _ = Describe("KubeVirt config creator", func() {
 
 	It("should create config with feature gates", func() {
 		Expect(cfg.FeatureGates).To(BeEquivalentTo(featureGates))
-	})
-
-	It("should create config with LiveMigration enabled", func() {
-		Expect(cfg.LiveMigrationEnabled()).To(BeTrue())
 	})
 })

--- a/pkg/providers/ovirt/validation/validators/vm-validator.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator.go
@@ -62,9 +62,6 @@ func ValidateVM(vm *ovirtsdk.Vm, config kvConfig.KubeVirtConfig, finder *otempla
 	if failure, valid := isValidOrigin(vm); !valid {
 		results = append(results, failure)
 	}
-	if failure, valid := isValidPlacementPolicy(vm, config.LiveMigrationEnabled()); !valid {
-		results = append(results, failure)
-	}
 	if failure, valid := isValidRandomNumberGeneratorSource(vm); !valid {
 		results = append(results, failure)
 	}

--- a/pkg/providers/ovirt/validation/validators/vm-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	config "github.com/kubevirt/vm-import-operator/pkg/config/kubevirt"
 	kvConfig "github.com/kubevirt/vm-import-operator/pkg/config/kubevirt"
 	otemplates "github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/templates"
 	"github.com/kubevirt/vm-import-operator/pkg/templates"
@@ -311,27 +310,6 @@ var _ = Describe("Validating VM", func() {
 
 		Expect(failures).To(HaveLen(1))
 		Expect(failures[0].ID).To(Equal(validators.VMOriginID))
-	})
-	It("should flag vm with placement_policy.affinity == migratable  and live migration disabled", func() {
-		var vm = newVM()
-		vm.SetPlacementPolicy(
-			ovirtsdk.NewVmPlacementPolicyBuilder().Affinity(ovirtsdk.VMAFFINITY_MIGRATABLE).MustBuild())
-
-		failures := validators.ValidateVM(vm, kvConfig, templateFinder)
-
-		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(validators.VMPlacementPolicyAffinityID))
-	})
-	It("should accept vm with placement_policy.affinity == migratable and live migration enabled", func() {
-		var vm = newVM()
-		vm.SetPlacementPolicy(
-			ovirtsdk.NewVmPlacementPolicyBuilder().Affinity(ovirtsdk.VMAFFINITY_MIGRATABLE).MustBuild())
-
-		kvConfig := config.KubeVirtConfig{FeatureGates: "LiveMigration"}
-
-		failures := validators.ValidateVM(vm, kvConfig, templateFinder)
-
-		Expect(failures).To(BeEmpty())
 	})
 	table.DescribeTable("should flag VM with illegal random number generator source", func(source string) {
 		vm := newVM()


### PR DESCRIPTION
Removes the LiveMigration validation, because KubeVirt LiveMigration being enabled or not has no bearing on whether or not an oVirt VM can be migrated to it, so this should not block import.

Makes ImportWithoutTemplate configurable via the vm-import-controller-config config map.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1977277