### PR TITLE
Remove redundant condition check from shouldStartVm

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -1047,11 +1047,7 @@ func shouldReconcile(instance *v2vv1.VirtualMachineImport) bool {
 }
 
 func shouldStartVM(instance *v2vv1.VirtualMachineImport) bool {
-	return conditions.HasSucceededConditionOfReason(instance.Status.Conditions, v2vv1.VirtualMachineReady) &&
-		((instance.Spec.StartVM != nil && *instance.Spec.StartVM) ||
-			(instance.Spec.StartVM == nil &&
-				instance.Spec.Warm &&
-				instance.Annotations[sourceVMInitialState] == string(provider.VMStatusUp)))
+	return (instance.Spec.StartVM != nil && *instance.Spec.StartVM) || (instance.Spec.StartVM == nil && instance.Spec.Warm && instance.Annotations[sourceVMInitialState] == string(provider.VMStatusUp))
 }
 
 func shouldConvertGuest(provider provider.Provider, instance *v2vv1.VirtualMachineImport) bool {


### PR DESCRIPTION
`updateConditionsAfterSuccess` doesn't set the Ready condition on the copy of the vm import in memory, so the check in `shouldStartVm` would always be false. It seems that `shouldStartVm` must not have ever worked due to this issue, but thankfully the condition check is redundant and can just be removed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1957791

Signed-off-by: Sam Lucidi <slucidi@redhat.com>