### PR TITLE
Use sha1 for oVirt DV names to avoid truncating

### DIFF
--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller.go
@@ -616,7 +616,7 @@ func (r *ReconcileVirtualMachineImport) importDisks(provider provider.Provider, 
 		if err != nil && k8serrors.IsNotFound(err) {
 			// We have to validate the disk status, so we are sure, the disk wasn't manipulated,
 			// before we execute the import:
-			valid, err := provider.ValidateDiskStatus(dv.Name)
+			valid, err := provider.ValidateDiskStatus(dv)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
+++ b/pkg/controller/virtualmachineimport/virtualmachineimport_controller_test.go
@@ -1974,7 +1974,7 @@ func (p *mockProvider) TestConnection() error {
 }
 
 // ValidateDiskStatus return true if disk is valid
-func (p *mockProvider) ValidateDiskStatus(string) (bool, error) {
+func (p *mockProvider) ValidateDiskStatus(volume cdiv1.DataVolume) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/controller/virtualmachineimport/warmimport.go
+++ b/pkg/controller/virtualmachineimport/warmimport.go
@@ -142,12 +142,12 @@ func (r *ReconcileVirtualMachineImport) ensureDisksExist(provider provider.Provi
 
 		// We have to validate the disk status, so we are sure, the disk wasn't manipulated,
 		// before we execute the import:
-		valid, err := provider.ValidateDiskStatus(dvName.Name)
+		valid, err := provider.ValidateDiskStatus(dvDef)
 		if err != nil {
 			return false, err
 		}
 		if !valid {
-			err := r.endDiskImportFailed(provider, instance, dv, "disk is in illegal status")
+			err := r.endDiskImportFailed(provider, instance, &dvDef, "disk is in illegal status")
 			if err != nil {
 				return false, err
 			}

--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"strings"
 
@@ -825,6 +826,7 @@ func getDiskAttachmentByID(id string, diskAttachments *ovirtsdk.DiskAttachmentSl
 }
 
 func buildDataVolumeName(targetVMName string, diskAttachID string) string {
-	dvName, _ := utils.NormalizeName(targetVMName + "-" + diskAttachID)
-	return dvName
+	sha := sha1.New()
+	sha.Write([]byte(targetVMName + diskAttachID))
+	return fmt.Sprintf("%x", sha.Sum(nil))
 }

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -24,7 +24,7 @@ const maxMemoryGI = 4 * 1024 * 1024 * 1024
 
 var (
 	targetVMName       = "myvm"
-	expectedDVName     = targetVMName + "-" + "123"
+	expectedDVName     = "d7bc458c04f4863b9e517c9b1661fbd34c02dc02"
 	filesystemOverhead = cdiv1.FilesystemOverhead{
 		Global: "0.0",
 	}

--- a/pkg/providers/ovirt/provider.go
+++ b/pkg/providers/ovirt/provider.go
@@ -235,7 +235,7 @@ func (o *OvirtProvider) PrepareResourceMapping(externalResourceMapping *v2vv1.Re
 }
 
 // ValidateDiskStatus validate current status of the disk in oVirt env:
-func (o *OvirtProvider) ValidateDiskStatus(diskName string) (bool, error) {
+func (o *OvirtProvider) ValidateDiskStatus(dv cdiv1.DataVolume) (bool, error) {
 	// Refresh cached VM data:
 	err := o.LoadVM(o.instance.Spec.Source)
 	if err != nil {
@@ -244,10 +244,12 @@ func (o *OvirtProvider) ValidateDiskStatus(diskName string) (bool, error) {
 
 	// Find the disk by ID and validate the status:
 	if diskAttachments, ok := o.vm.DiskAttachments(); ok {
-		for _, disk := range diskAttachments.Slice() {
-			if diskID, ok := disk.Id(); ok {
-				if strings.Contains(diskName, diskID) {
-					return o.validator.Validator.ValidateDiskStatus(*disk), nil
+		for _, da := range diskAttachments.Slice() {
+			if disk, ok := da.Disk(); ok {
+				if diskID, ok := disk.Id(); ok {
+					if strings.Contains(dv.Spec.Source.Imageio.DiskID, diskID) {
+						return o.validator.Validator.ValidateDiskStatus(*da), nil
+					}
 				}
 			}
 		}

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -25,7 +25,7 @@ type Provider interface {
 	LoadVM(v2vv1.VirtualMachineImportSourceSpec) error
 	PrepareResourceMapping(*v2vv1.ResourceMappingSpec, v2vv1.VirtualMachineImportSourceSpec)
 	Validate() ([]v2vv1.VirtualMachineImportCondition, error)
-	ValidateDiskStatus(string) (bool, error)
+	ValidateDiskStatus(cdiv1.DataVolume) (bool, error)
 	StopVM(*v2vv1.VirtualMachineImport, rclient.Client) error
 	CreateMapper() (Mapper, error)
 	GetVMStatus() (VMStatus, error)

--- a/pkg/providers/vmware/provider.go
+++ b/pkg/providers/vmware/provider.go
@@ -489,7 +489,7 @@ func (r *VmwareProvider) Close() {
 }
 
 // ValidateDiskStatus is a no-op which is present in order to satisfy the Provider interface.
-func (r *VmwareProvider) ValidateDiskStatus(_ string) (bool, error) {
+func (r *VmwareProvider) ValidateDiskStatus(_ cdiv1.DataVolume) (bool, error) {
 	return true, nil
 }
 


### PR DESCRIPTION
If an oVirt VM being migrated had a very long name, the attempt to normalize the datavolume names in `buildDataVolumeName` could result in the DV names being significantly truncated; this could cause a VM with multiple DVs to fail. To continue deterministically building the DV name while avoiding the truncation issue, this PR generates a sha1 hash from the name of the VM and the disk ID to use as the name.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2000021

Signed-off-by: Sam Lucidi <slucidi@redhat.com>