### PR TITLE
Remove ovirt timezone validation

### DIFF
--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -798,7 +798,9 @@ func (o *OvirtMapper) mapFeatures() *kubevirtv1.Features {
 }
 
 func (o *OvirtMapper) mapTimeZone() *kubevirtv1.Clock {
+	clock := kubevirtv1.Clock{Timer: &kubevirtv1.Timer{}}
 	offset := kubevirtv1.ClockOffsetUTC{}
+
 	if tz, ok := o.vm.TimeZone(); ok {
 		if utcOffset, ok := tz.UtcOffset(); ok {
 			parsedOffset, err := utils.ParseUtcOffsetToSeconds(utcOffset)
@@ -807,10 +809,15 @@ func (o *OvirtMapper) mapTimeZone() *kubevirtv1.Clock {
 			} else {
 				log.Info("VM's utc offset is malformed: " + err.Error())
 			}
+		} else if tzName, ok := tz.Name(); ok {
+			timezone := kubevirtv1.ClockOffsetTimezone(tzName)
+			clock.Timezone = &timezone
 		}
 	}
-	clock := kubevirtv1.Clock{Timer: &kubevirtv1.Timer{}}
-	clock.UTC = &offset
+
+	if clock.Timezone == nil {
+		clock.UTC = &offset
+	}
 
 	return &clock
 }

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		Expect(*clock.UTC.OffsetSeconds).To(BeEquivalentTo(3600))
 	})
 
-	It("should create UTC clock without offset", func() {
+	It("should create UTC clock with timezone by name", func() {
 		vm = createVM()
 		vm.SetTimeZone(ovirtsdk.NewTimeZoneBuilder().
 			Name("Etc/GMT").MustBuild())
@@ -214,9 +214,9 @@ var _ = Describe("Test mapping virtual machine attributes", func() {
 		vmSpec, _ = mapper.MapVM(&targetVMName, &kubevirtv1.VirtualMachine{})
 
 		clock := vmSpec.Spec.Template.Spec.Domain.Clock
-		Expect(clock.Timezone).To(BeNil())
-		Expect(clock.UTC).NotTo(BeNil())
-		Expect(clock.UTC.OffsetSeconds).To(BeNil())
+		Expect(clock.Timezone).NotTo(BeNil())
+		Expect(string(*clock.Timezone)).To(Equal("Etc/GMT"))
+		Expect(clock.UTC).To(BeNil())
 	})
 
 	It("should handle cluster default bios type", func() {

--- a/pkg/providers/ovirt/validation/validators/vm-validator.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator.go
@@ -27,9 +27,6 @@ func ValidateVM(vm *ovirtsdk.Vm, config kvConfig.KubeVirtConfig, finder *otempla
 	if failure, valid := isValidStatus(vm); !valid {
 		results = append(results, failure)
 	}
-	if failure, valid := isValidTimezone(vm); !valid {
-		results = append(results, failure)
-	}
 	results = append(results, isValidCPU(vm)...)
 	if failure, valid := isValidCPUShares(vm); !valid {
 		results = append(results, failure)
@@ -204,20 +201,6 @@ func isValidStatus(vm *ovirtsdk.Vm) (ValidationFailure, bool) {
 		ID:      VMStatusID,
 		Message: "VM doesn't have any status. Must be 'up' or 'down'.",
 	}, false
-}
-
-func isValidTimezone(vm *ovirtsdk.Vm) (ValidationFailure, bool) {
-	if tz, ok := vm.TimeZone(); ok {
-		if name, ok := tz.Name(); ok {
-			if !utils.IsUtcCompatible(name) {
-				return ValidationFailure{
-					ID:      VMTimezoneID,
-					Message: "VM's timezone is not UTC-compatible. It should have offset of 0 and not observe DST",
-				}, false
-			}
-		}
-	}
-	return ValidationFailure{}, true
 }
 
 func isValidBootMenu(bios *ovirtsdk.Bios) (ValidationFailure, bool) {

--- a/pkg/providers/ovirt/validation/validators/vm-validator_test.go
+++ b/pkg/providers/ovirt/validation/validators/vm-validator_test.go
@@ -39,23 +39,6 @@ var _ = Describe("Validating VM", func() {
 		Expect(failures).To(HaveLen(1))
 		Expect(failures[0].ID).To(Equal(validators.VMStatusID))
 	})
-	It("should accept VM with no timezone ", func() {
-		var vm = newVM()
-		vm.SetTimeZone(ovirtsdk.NewTimeZoneBuilder().MustBuild())
-
-		failures := validators.ValidateVM(vm, kvConfig, templateFinder)
-
-		Expect(failures).To(BeEmpty())
-	})
-	It("should reject VM with wrong timezone ", func() {
-		var vm = newVM()
-		vm.SetTimeZone(ovirtsdk.NewTimeZoneBuilder().Name("Etc/GMT+1").MustBuild())
-
-		failures := validators.ValidateVM(vm, kvConfig, templateFinder)
-
-		Expect(failures).To(HaveLen(1))
-		Expect(failures[0].ID).To(Equal(validators.VMTimezoneID))
-	})
 	table.DescribeTable("should accept VM with legal status", func(status ovirtsdk.VmStatus) {
 		vm := newVM()
 		vm.SetStatus(status)


### PR DESCRIPTION
Setting the VM timezone has been fixed in Kubevirt, so this should no longer be necessary.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1997668

Signed-off-by: Sam Lucidi <slucidi@redhat.com>