### PR TITLE
Apply overhead after rounding to next 1M.

### DIFF
--- a/pkg/providers/ovirt/mapper/mapper.go
+++ b/pkg/providers/ovirt/mapper/mapper.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"crypto/sha1"
 	"fmt"
+	"math"
 	"strings"
 
 	oos "github.com/kubevirt/vm-import-operator/pkg/providers/ovirt/os"
@@ -279,7 +280,8 @@ func (o *OvirtMapper) MapDataVolumes(targetVMName *string, filesystemOverhead cd
 		overhead := utils.GetOverheadForStorageClass(filesystemOverhead, sdClass)
 
 		blockSize := int64(1048576)
-		sizeWithOverhead := utils.RoundUp(int64(float64(diskSize)/(1-overhead)), blockSize)
+		alignedSize := utils.RoundUp(diskSize, blockSize)
+		sizeWithOverhead := int64(math.Ceil(float64(alignedSize) / (1 - overhead)))
 		diskSizeConverted, err := utils.FormatBytes(sizeWithOverhead)
 		if err != nil {
 			return dvs, err

--- a/pkg/providers/ovirt/mapper/mapper_test.go
+++ b/pkg/providers/ovirt/mapper/mapper_test.go
@@ -455,7 +455,7 @@ var _ = Describe("Test mapping disks", func() {
 
 		Expect(dv.Spec.PVC.Resources.Requests).To(HaveKey(corev1.ResourceStorage))
 		storageResource := dv.Spec.PVC.Resources.Requests[corev1.ResourceStorage]
-		Expect(storageResource.Value()).To(BeEquivalentTo(1136656384))
+		Expect(storageResource.Value()).To(BeEquivalentTo(1136234735))
 
 		Expect(dv.Spec.PVC.StorageClassName).To(Not(BeNil()))
 		Expect(*dv.Spec.PVC.StorageClassName).To(Equal("storageclassname"))
@@ -488,7 +488,7 @@ var _ = Describe("Test mapping disks", func() {
 
 		Expect(dv.Spec.PVC.Resources.Requests).To(HaveKey(corev1.ResourceStorage))
 		storageResource := dv.Spec.PVC.Resources.Requests[corev1.ResourceStorage]
-		Expect(storageResource.Value()).To(BeEquivalentTo(1136656384))
+		Expect(storageResource.Value()).To(BeEquivalentTo(1136234735))
 
 		Expect(dv.Spec.PVC.StorageClassName).To(Not(BeNil()))
 		Expect(*dv.Spec.PVC.StorageClassName).To(Equal(scName))

--- a/pkg/providers/vmware/mapper/mapper.go
+++ b/pkg/providers/vmware/mapper/mapper.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -315,8 +316,10 @@ func (r *VmwareMapper) MapDataVolumes(_ *string, filesystemOverhead cdiv1.Filesy
 		storageClass := r.getStorageClassForDisk(mapping)
 
 		overhead := utils.GetOverheadForStorageClass(filesystemOverhead, storageClass)
+
 		blockSize := int64(1048576)
-		capacityWithOverhead := utils.RoundUp(int64(float64(disk.Capacity)/(1-overhead)), blockSize)
+		capacityWithAlignment := utils.RoundUp(disk.Capacity, blockSize)
+		capacityWithOverhead := int64(math.Ceil(float64(capacityWithAlignment) / (1 - overhead)))
 		capacityAsQuantity, err := bytesToQuantity(capacityWithOverhead)
 		if err != nil {
 			return nil, err

--- a/pkg/providers/vmware/mapper/mapper_test.go
+++ b/pkg/providers/vmware/mapper/mapper_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Test mapping disks", func() {
 		// check that disk overheads are set correctly
 		Expect(dvs[expectedDiskName1].Spec.PVC.Resources.Requests).To(HaveKey(v1.ResourceStorage))
 		storageResource := dvs[expectedDiskName1].Spec.PVC.Resources.Requests[v1.ResourceStorage]
-		Expect(storageResource.Value()).To(BeEquivalentTo(2273312768))
+		Expect(storageResource.Value()).To(BeEquivalentTo(2272469469))
 
 		Expect(dvs[expectedDiskName2].Spec.PVC.Resources.Requests).To(HaveKey(v1.ResourceStorage))
 		storageResource = dvs[expectedDiskName2].Spec.PVC.Resources.Requests[v1.ResourceStorage]


### PR DESCRIPTION
CDI needs to have the filesystem overhead applied after rounding up to the nearest block size, so that it doesn't reduce too much overhead size when rounding down for qemu-img. Addresses [BZ#1996110](https://bugzilla.redhat.com/show_bug.cgi?id=1996110).

```release-note
NONE
```